### PR TITLE
fix: akamai

### DIFF
--- a/cmd/akamai/command.go
+++ b/cmd/akamai/command.go
@@ -35,6 +35,7 @@ var (
 	nodeTypeFlag             string
 	nodeCountFlag            string
 	installCatalogApps       string
+	installKubefirstProFlag  bool
 
 	// RootCredentials
 	copyArgoCDPasswordToClipboardFlag bool
@@ -100,6 +101,7 @@ func Create() *cobra.Command {
 	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/kubefirst/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
 	createCmd.Flags().StringVar(&installCatalogApps, "install-catalog-apps", "", "comma separated values to install after provision")
 	createCmd.Flags().BoolVar(&useTelemetryFlag, "use-telemetry", true, "whether to emit telemetry")
+	createCmd.Flags().BoolVar(&installKubefirstProFlag, "install-kubefirst-pro", true, "whether or not to install kubefirst pro")
 
 	return createCmd
 }

--- a/cmd/akamai/command.go
+++ b/cmd/akamai/command.go
@@ -56,7 +56,7 @@ func NewCommand() *cobra.Command {
 		Long:  "kubefirst akamai",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("To learn more about akamai in kubefirst, run:")
-			fmt.Println("  kubefirst akamai --help")
+			fmt.Println("  kubefirst beta akamai --help")
 
 			if progress.Progress != nil {
 				progress.Progress.Quit()


### PR DESCRIPTION
## Description
added pro feature flag which was missing (also refer [https://github.com/konstructio/kubefirst-api/compare/akamai-upgrade?expand=1](url) and [https://github.com/konstructio/gitops-template/compare/main...akamai-upgrade](url))

## How to test
build the kubefirst binary locally and have kubefirst-api running locally,and run "./kubefirst beta akamai --alerts-email <ALERTS_EMAIL> --github-org <GITHUB_ORG> --gitops-template-branch akamai-upgrade --domain-name <DOMAIN_NAME> --cluster-name <CLUSTER_NAME>"
