### PR TITLE
fix: launch deployed message

### DIFF
--- a/internal/launch/cmd.go
+++ b/internal/launch/cmd.go
@@ -37,7 +37,6 @@ var consoleClusterName = "kubefirst-console"
 // Up
 func Up(additionalHelmFlags []string, inCluster, useTelemetry bool) {
 	if viper.GetBool("launch.deployed") {
-
 		message := `##
 Kubefirst console has already been deployed. To start over, run` + "`" + `kubefirst launch down` + "`" + `to completely remove the existing console.`
 

--- a/internal/launch/cmd.go
+++ b/internal/launch/cmd.go
@@ -37,7 +37,12 @@ var consoleClusterName = "kubefirst-console"
 // Up
 func Up(additionalHelmFlags []string, inCluster, useTelemetry bool) {
 	if viper.GetBool("launch.deployed") {
-		progress.Error("Kubefirst console has already been deployed. To start over, run `kubefirst launch down` to completely remove the existing console.")
+
+		message := `##
+Kubefirst console has already been deployed. To start over, run` + "`" + `kubefirst launch down` + "`" + `to completely remove the existing console.`
+
+		progress.Success(message)
+		return
 	}
 
 	if !inCluster {


### PR DESCRIPTION
## Description

After running `kubefirst launch up` twice, there was no message 

![Screenshot 2024-10-21 at 8 57 40 AM](https://github.com/user-attachments/assets/46e9db12-0053-419e-b368-9b50976cfd4c)

## Related Issue(s)
Fixes https://linear.app/konstruct/issue/KRA-19/failure-for-ui-install-command-kubefirst-launch-up

## How to test
- Run `kubefirst launch up`
- Once its done and try to run again `kubefirst launch up`
- Warning should show up to run `kubefirst launch down`