### PR TITLE
feat: update doc links to kubefirst.konstruct.io/docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Kubefirst is created using the [Go Programming Language](https://go.dev). To set
 
 Once Go is installed, you can run Kubefirst from any branch using `go run .`. Go will automatically install the needed modules listed in the [go.mod](go.mod) file. Since Go is a compiled programming language, every time you use the `run` command, Go will compile the code before running it. If you want to save time, you can compile your code using `go build`, which will generate a file named `kubefirst`. You will then be able to run your compiled version with the `./kubefirst` command.
 
-If you want to create a [Civo cluster](https://docs.kubefirst.io/kubefirst/local/install.html), the command would be `go run . civo create`.
+If you want to create a [Civo cluster](https://kubefirst.konstruct.io/docs/civo/quick-start/install/cli), the command would be `go run . civo create`.
 
 #### GitOps Template
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.kubefirst.io/">Install</a>&nbsp;|&nbsp;
+  <a href="https://kubefirst.konstruct.io/docs/">Install</a>&nbsp;|&nbsp;
   <a href="https://twitter.com/kubefirst">Twitter</a>&nbsp;|&nbsp;
   <a href="https://www.linkedin.com/company/kubefirst">LinkedIn</a>&nbsp;|&nbsp;
   <a href="https://join.slack.com/t/kubefirst/shared_invite/zt-r0r9cfts-OVnH0ooELDLm9n9p2aU7fw">Slack</a>&nbsp;|&nbsp;
@@ -31,21 +31,21 @@ The Kubefirst CLI creates instant GitOps platforms that integrate some of the be
 
 Each of our platforms have install guides that detail the prerequesites, commands, and resulting platform that you'll receive.
 
-- [k3d (local)](https://docs.kubefirst.io/k3d/overview/)
-- [AWS](https://docs.kubefirst.io/aws/overview/)
-- [Civo](https://docs.kubefirst.io/civo/overview/)
-- [DigitalOcean](https://docs.kubefirst.io/do/overview/)
+- [k3d (local)](https://kubefirst.konstruct.io/docs/k3d/overview)
+- [AWS](https://kubefirst.konstruct.io/docs/aws/overview)
+- [Civo](https://kubefirst.konstruct.io/docs/civo/overview)
+- [DigitalOcean](https://kubefirst.konstruct.io/docs/do/overview)
 
 In beta:
 
 - [Akamai](https://docs.kubefirst.io/akamai/overview)
-- [Google Cloud](https://docs.kubefirst.io/gcp/overview/)
-- [K3s](https://docs.kubefirst.io/k3s/overview)
-- [Vultr](https://docs.kubefirst.io/vultr/overview/)
+- [Google Cloud](https://kubefirst.konstruct.io/docs/gcp/overview)
+- [K3s](https://kubefirst.konstruct.io/docs/k3s/overview)
+- [Vultr](https://kubefirst.konstruct.io/docs/vultr/overview)
 
 ## Overview
 
-<https://docs.kubefirst.io>
+<https://kubefirst.konstruct.io/docs/>
 
 ![kubefirst architecture diagram](images/kubefirst-arch.png)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ var rootCmd = &cobra.Command{
 	Short: "kubefirst management cluster installer base command",
 	Long: `kubefirst management cluster installer provisions an
 	open source application delivery platform in under an hour.
-	checkout the docs at docs.kubefirst.io.`,
+	checkout the docs at https://kubefirst.konstruct.io/docs/.`,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 		// wire viper config for flags for all commands
 		return configs.InitializeViperConfig(cmd)

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -188,7 +188,7 @@ func Destroy(_ *cobra.Command, _ []string) error {
 #### :tada: Success` + "`Your k3d kubefirst platform has been destroyed.`" + `
 
 ### :blue_book: To delete a management cluster please see documentation:
-https://docs.kubefirst.io/` + cloudProvider + `/deprovision
+https://kubefirst.konstruct.io/docs/` + cloudProvider + `/deprovision
 `
 
 	progress.Success(successMessage)

--- a/internal/progress/message.go
+++ b/internal/progress/message.go
@@ -54,7 +54,7 @@ func DisplayLogHints(estimatedTime int) {
 	logFile := viper.GetString("k1-paths.log-file")
 	cloudProvider := viper.GetString("kubefirst.cloud-provider")
 
-	documentationLink := "https://docs.kubefirst.io/"
+	documentationLink := "https://kubefirst.konstruct.io/docs/"
 	if cloudProvider != "" {
 		documentationLink += cloudProvider + `/quick-start/install/cli`
 	}


### PR DESCRIPTION
## Description
Update doc links from `https://docs.kubefirst.io/` to `https://kubefirst.konstruct.io/docs/`


## Related Issue(s)
![Screenshot from 2024-10-22 09-22-38](https://github.com/user-attachments/assets/553bee41-dc3f-45a2-b4f8-07450ddcd37b)

## How to test
Run the following command in the current branch
```
$ go run main.go --help
kubefirst management cluster installer provisions an
	open source application delivery platform in under an hour.
	checkout the docs at https://kubefirst.konstruct.io/docs/.

```
