### PR TITLE
fix: delete k1dir instead of kubeconfig file

### DIFF
--- a/cmd/k3d/destroy.go
+++ b/cmd/k3d/destroy.go
@@ -223,9 +223,9 @@ func destroyK3d(_ *cobra.Command, _ []string) error {
 		viper.WriteConfig()
 	}
 
-	if _, err := os.Stat(config.K1Dir + "/kubeconfig"); !os.IsNotExist(err) {
-		if err := os.Remove(config.K1Dir + "/kubeconfig"); err != nil {
-			return fmt.Errorf("unable to delete %q: %w", config.K1Dir+"/kubeconfig", err)
+	if _, err := os.Stat(config.K1Dir); !os.IsNotExist(err) {
+		if err := os.RemoveAll(config.K1Dir); err != nil {
+			return fmt.Errorf("unable to delete %q: %w", config.K1Dir, err)
 		}
 	}
 	time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
## Description
when we do "kubefirst k3d destroy",it doesnt delete the k1dir repo which return an error that "repo already exists" when we try to provision a k3d cluster again and the cleanup path is also wrong one, it should be (config.K1Dir + "<cluster_name>/kubeconfig")

## Testing
Provision a Kubefirst in k3d environment
Clone the repo
run:
```bash
go build .
./kubefirst k3d destroy
```