### PR TITLE
fix: delete k1dir instead of kubeconfig file

### DIFF
--- a/cmd/k3d/destroy.go
+++ b/cmd/k3d/destroy.go
@@ -223,10 +223,8 @@ func destroyK3d(_ *cobra.Command, _ []string) error {
 		viper.WriteConfig()
 	}
 
-	if _, err := os.Stat(config.K1Dir); !os.IsNotExist(err) {
-		if err := os.RemoveAll(config.K1Dir); err != nil {
-			return fmt.Errorf("unable to delete %q: %w", config.K1Dir, err)
-		}
+	if err := os.RemoveAll(config.K1Dir); err != nil {
+		return fmt.Errorf("unable to delete %q: %w", config.K1Dir, err)
 	}
 	time.Sleep(200 * time.Millisecond)
 	fmt.Printf("Your kubefirst platform running in %q has been destroyed.", k3d.CloudProvider)

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -127,9 +127,9 @@ func runReset() error {
 		return fmt.Errorf("error writing viper config: %w", err)
 	}
 
-	if _, err := os.Stat(k1Dir + "/kubeconfig"); !os.IsNotExist(err) {
-		if err := os.Remove(k1Dir + "/kubeconfig"); err != nil {
-			return fmt.Errorf("unable to delete %q folder, error: %w", k1Dir+"/kubeconfig", err)
+	if _, err := os.Stat(k1Dir); !os.IsNotExist(err) {
+		if err := os.RemoveAll(k1Dir); err != nil {
+			return fmt.Errorf("unable to delete %q folder, error: %w", k1Dir, err)
 		}
 	}
 

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -127,10 +127,8 @@ func runReset() error {
 		return fmt.Errorf("error writing viper config: %w", err)
 	}
 
-	if _, err := os.Stat(k1Dir); !os.IsNotExist(err) {
-		if err := os.RemoveAll(k1Dir); err != nil {
-			return fmt.Errorf("unable to delete %q folder, error: %w", k1Dir, err)
-		}
+	if err := os.RemoveAll(k1Dir); err != nil {
+		return fmt.Errorf("unable to delete %q folder, error: %w", k1Dir, err)
 	}
 
 	progressPrinter.IncrementTracker("removing-platform-content")


### PR DESCRIPTION
## Description
when we do "kubefirst reset",it doesnt delete the k1dir repo which return an error that "repo already exists" when we try to provision a cluster with same name again,this will fix it
