### PR TITLE
fix(azure): make the dns resource group optional

### DIFF
--- a/cmd/azure/command.go
+++ b/cmd/azure/command.go
@@ -97,7 +97,7 @@ func Create() *cobra.Command {
 	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", azureDefaults.NodeCount, "the node count for the cluster")
 	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", azureDefaults.InstanceSize, "the instance size of the cluster to create")
 	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "azure", fmt.Sprintf("the dns provider - one of: %s", supportedDNSProviders))
-	createCmd.Flags().StringVar(&dnsAzureResourceGroup, "dns-azure-resource-group", "", "the resource group where the Azure DNS Zone is hosted")
+	createCmd.Flags().StringVar(&dnsAzureResourceGroup, "dns-azure-resource-group", "", "the name of the resource group where the DNS Zone exists. If not set, the first matching zone will be used")
 	createCmd.Flags().StringVar(&subdomainNameFlag, "subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
 	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "the Azure/Cloudflare DNS hosted zone name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")

--- a/cmd/azure/create.go
+++ b/cmd/azure/create.go
@@ -51,7 +51,7 @@ func createAzure(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider, cliFlags.DNSProvider, cliFlags.DNSAzureRG)
+	err = ValidateProvidedFlags(cliFlags.GitProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return nil
@@ -112,7 +112,7 @@ func createAzure(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func ValidateProvidedFlags(gitProvider, dnsProvider, dnsAzureResourceGroup string) error {
+func ValidateProvidedFlags(gitProvider string) error {
 	progress.AddStep("Validate provided flags")
 
 	for _, env := range envvarSecrets {
@@ -138,9 +138,7 @@ func ValidateProvidedFlags(gitProvider, dnsProvider, dnsAzureResourceGroup strin
 		}
 	}
 
-	if dnsProvider == "azure" && dnsAzureResourceGroup == "" {
-		return fmt.Errorf("the resource group for the azure dns zone is required when using azure dns")
-	}
+	progress.CompleteStep("Validate provided flags")
 
 	return nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This makes the resource group for Azure DNS optional.

Once accepted, this will require an update of the designs of the console to remove the required field on the Azure DNS section @donnalux @CristhianF7 

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #2338 

## How to test
<!-- Provide steps to test this PR -->
1. Ensure that the CLI and API branches are loaded (see #2330 for branches)
2. Add a `replace` in the CLI's `go.mod`
   ```go
   replace (
     github.com/konstructio/kubefirst-api => ../kubefirst-api
   )
   ```
3. Run the normal command without the `--dns-azure-resource-group` flag:

## GitHub - Azure DNS
```shell
go run . beta azure create \
  --alerts-email <email> \
  --github-org <org> \
  --domain-name <domain> \
  --gitops-template-branch sje/azure-optional-dns
```

## GitLab - Azure DNS
```shell
go run . beta azure create \
  --alerts-email <email> \
  --domain-name <domain> \
  --git-provider gitlab \
  --gitlab-group <group> \
  --gitops-template-branch sje/azure-optional-dns
```

## GitHub - Cloudflare DNS
```shell
go run . beta azure create \
  --alerts-email <email> \
  --github-org <org> \
  --domain-name <domain> \
  --gitops-template-branch sje/azure-optional-dns \
  --dns-provider cloudflare \
  --subdomain <subdomain>
```

## GitLab - Cloudflare DNS
```shell
go run . beta azure create \
  --alerts-email <email> \
  --domain-name <domain> \
  --git-provider gitlab \
  --gitlab-group <group> \
  --gitops-template-branch sje/azure-optional-dns \
  --dns-provider cloudflare \
  --subdomain <subdomain>
```