### PR TITLE
fix: delete kubefirst file when doing kubefirst reset - KRA-73

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -7,6 +7,7 @@ See the LICENSE file for more details.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -132,13 +133,18 @@ func runReset() error {
 		return fmt.Errorf("unable to delete %q folder, error: %w", k1Dir, err)
 	}
 
-	if err := os.Remove(kubefirstConfig); err != nil {
+	if _, err := os.Stat(kubefirstConfig); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Info().Msgf("%q does not exist, continuing", kubefirstConfig)
+		} else {
+			return fmt.Errorf("error checking %q: %w", kubefirstConfig, err)
+		}
+	} else if err := os.Remove(kubefirstConfig); err != nil {
 		return fmt.Errorf("unable to remove %q, error: %w", kubefirstConfig, err)
 	}
 
 	progressPrinter.IncrementTracker("removing-platform-content")
 	time.Sleep(time.Second * 2)
 	progress.Progress.Quit()
-
 	return nil
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -107,6 +107,7 @@ func runReset() error {
 		return fmt.Errorf("unable to get user home directory: %w", err)
 	}
 	k1Dir := fmt.Sprintf("%s/.k1", homePath)
+	kubefirstConfig := fmt.Sprintf("%s/.kubefirst", homePath)
 
 	if err := utils.ResetK1Dir(k1Dir); err != nil {
 		return fmt.Errorf("error resetting k1 directory: %w", err)
@@ -129,6 +130,10 @@ func runReset() error {
 
 	if err := os.RemoveAll(k1Dir); err != nil {
 		return fmt.Errorf("unable to delete %q folder, error: %w", k1Dir, err)
+	}
+
+	if err := os.Remove(kubefirstConfig); err != nil {
+		return fmt.Errorf("unable to remove %q, error: %w", kubefirstConfig, err)
 	}
 
 	progressPrinter.IncrementTracker("removing-platform-content")


### PR DESCRIPTION
## Description

First PR! 🎉 

This removes the `.kubefirst` file that lives at the root alongside the `.k1` directory. Without removing this file, kubefirst hangs after validating git configuration and never tries to spin up the local cluster for initial setup if there is a partially completed run gumming things up.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #reset

## How to test

Couldn't find any existing tests 🤔 

