### PR TITLE
Housekeeping: delete barely used flags.

### DIFF
--- a/cmd/akamai/command.go
+++ b/cmd/akamai/command.go
@@ -16,32 +16,6 @@ import (
 )
 
 var (
-	// Create
-	alertsEmailFlag          string
-	ciFlag                   bool
-	cloudRegionFlag          string
-	clusterNameFlag          string
-	clusterTypeFlag          string
-	dnsProviderFlag          string
-	subdomainNameFlag        string
-	domainNameFlag           string
-	githubOrgFlag            string
-	gitlabGroupFlag          string
-	gitProviderFlag          string
-	gitProtocolFlag          string
-	gitopsTemplateURLFlag    string
-	gitopsTemplateBranchFlag string
-	useTelemetryFlag         bool
-	nodeTypeFlag             string
-	nodeCountFlag            string
-	installCatalogApps       string
-	installKubefirstProFlag  bool
-
-	// RootCredentials
-	copyArgoCDPasswordToClipboardFlag bool
-	copyKbotPasswordToClipboardFlag   bool
-	copyVaultPasswordToClipboardFlag  bool
-
 	// Supported providers
 	supportedDNSProviders = []string{"cloudflare"}
 	supportedGitProviders = []string{"github", "gitlab"}
@@ -81,27 +55,27 @@ func Create() *cobra.Command {
 	akamaiDefaults := constants.GetCloudDefaults().Akamai
 
 	// todo review defaults and update descriptions
-	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "email address for let's encrypt certificate notifications (required)")
+	createCmd.Flags().String("alerts-email", "", "email address for let's encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
-	createCmd.Flags().BoolVar(&ciFlag, "ci", false, "if running kubefirst in ci, set this flag to disable interactive features")
-	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "us-central", "the akamai region to provision infrastructure in")
-	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
-	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
-	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", akamaiDefaults.NodeCount, "the node count for the cluster")
-	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", akamaiDefaults.InstanceSize, "the instance size of the cluster to create")
-	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "cloudflare", fmt.Sprintf("the dns provider - one of: %q", supportedDNSProviders))
-	createCmd.Flags().StringVar(&subdomainNameFlag, "subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
-	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "the DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
+	createCmd.Flags().Bool("ci", false, "if running kubefirst in ci, set this flag to disable interactive features")
+	createCmd.Flags().String("cloud-region", "us-central", "the akamai region to provision infrastructure in")
+	createCmd.Flags().String("cluster-name", "kubefirst", "the name of the cluster to create")
+	createCmd.Flags().String("cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().String("node-count", akamaiDefaults.NodeCount, "the node count for the cluster")
+	createCmd.Flags().String("node-type", akamaiDefaults.InstanceSize, "the instance size of the cluster to create")
+	createCmd.Flags().String("dns-provider", "cloudflare", fmt.Sprintf("the dns provider - one of: %q", supportedDNSProviders))
+	createCmd.Flags().String("subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
+	createCmd.Flags().String("domain-name", "", "the DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")
-	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("the git provider - one of: %q", supportedGitProviders))
-	createCmd.Flags().StringVar(&gitProtocolFlag, "git-protocol", "https", fmt.Sprintf("the git protocol - one of: %q", supportedGitProtocolOverride))
-	createCmd.Flags().StringVar(&githubOrgFlag, "github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using github")
-	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
-	createCmd.Flags().StringVar(&gitopsTemplateBranchFlag, "gitops-template-branch", "", "the branch to clone for the gitops-template repository")
-	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
-	createCmd.Flags().StringVar(&installCatalogApps, "install-catalog-apps", "", "comma separated values to install after provision")
-	createCmd.Flags().BoolVar(&useTelemetryFlag, "use-telemetry", true, "whether to emit telemetry")
-	createCmd.Flags().BoolVar(&installKubefirstProFlag, "install-kubefirst-pro", true, "whether or not to install kubefirst pro")
+	createCmd.Flags().String("git-provider", "github", fmt.Sprintf("the git provider - one of: %q", supportedGitProviders))
+	createCmd.Flags().String("git-protocol", "https", fmt.Sprintf("the git protocol - one of: %q", supportedGitProtocolOverride))
+	createCmd.Flags().String("github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using github")
+	createCmd.Flags().String("gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
+	createCmd.Flags().String("gitops-template-branch", "", "the branch to clone for the gitops-template repository")
+	createCmd.Flags().String("gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
+	createCmd.Flags().String("install-catalog-apps", "", "comma separated values to install after provision")
+	createCmd.Flags().Bool("use-telemetry", true, "whether to emit telemetry")
+	createCmd.Flags().Bool("install-kubefirst-pro", true, "whether or not to install kubefirst pro")
 
 	return createCmd
 }
@@ -125,9 +99,9 @@ func RootCredentials() *cobra.Command {
 		RunE:  common.GetRootCredentials,
 	}
 
-	authCmd.Flags().BoolVar(&copyArgoCDPasswordToClipboardFlag, "argocd", false, "copy the ArgoCD password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyKbotPasswordToClipboardFlag, "kbot", false, "copy the kbot password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyVaultPasswordToClipboardFlag, "vault", false, "copy the vault password to the clipboard (optional)")
+	authCmd.Flags().Bool("argocd", false, "copy the ArgoCD password to the clipboard (optional)")
+	authCmd.Flags().Bool("kbot", false, "copy the kbot password to the clipboard (optional)")
+	authCmd.Flags().Bool("vault", false, "copy the vault password to the clipboard (optional)")
 
 	return authCmd
 }

--- a/cmd/akamai/create.go
+++ b/cmd/akamai/create.go
@@ -39,13 +39,13 @@ func createAkamai(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("catalog validation failed: %w", err)
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider)
+	err = ValidateProvidedFlags(cliFlags.GitProvider, cliFlags.DNSProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("failed to validate flags: %w", err)
 	}
 
-	utilities.CreateK1ClusterDirectory(clusterNameFlag)
+	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
 
 	gitAuth, err := gitShim.ValidateGitCredentials(cliFlags.GitProvider, cliFlags.GithubOrg, cliFlags.GitlabGroup)
 	if err != nil {
@@ -98,14 +98,14 @@ func createAkamai(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func ValidateProvidedFlags(gitProvider string) error {
+func ValidateProvidedFlags(gitProvider, dnsProvider string) error {
 	progress.AddStep("Validate provided flags")
 
 	if os.Getenv("LINODE_TOKEN") == "" {
 		return fmt.Errorf("your LINODE_TOKEN is not set - please set and re-run your last command")
 	}
 
-	if dnsProviderFlag == "cloudflare" {
+	if dnsProvider == "cloudflare" {
 		if os.Getenv("CF_API_TOKEN") == "" {
 			return fmt.Errorf("your CF_API_TOKEN environment variable is not set. Please set and try again")
 		}

--- a/cmd/azure/command.go
+++ b/cmd/azure/command.go
@@ -17,34 +17,6 @@ import (
 )
 
 var (
-	// Create
-	alertsEmailFlag          string
-	ciFlag                   bool
-	cloudRegionFlag          string
-	clusterNameFlag          string
-	clusterTypeFlag          string
-	dnsProviderFlag          string
-	dnsAzureResourceGroup    string
-	domainNameFlag           string
-	subdomainNameFlag        string
-	githubOrgFlag            string
-	gitlabGroupFlag          string
-	gitProviderFlag          string
-	gitProtocolFlag          string
-	gitopsTemplateURLFlag    string
-	gitopsTemplateBranchFlag string
-	useTelemetryFlag         bool
-	forceDestroyFlag         bool
-	nodeTypeFlag             string
-	nodeCountFlag            string
-	installCatalogApps       string
-	installKubefirstProFlag  bool
-
-	// RootCredentials
-	copyArgoCDPasswordToClipboardFlag bool
-	copyKbotPasswordToClipboardFlag   bool
-	copyVaultPasswordToClipboardFlag  bool
-
 	// Supported providers
 	supportedDNSProviders = []string{"azure", "cloudflare"}
 	supportedGitProviders = []string{"github", "gitlab"}
@@ -88,29 +60,29 @@ func Create() *cobra.Command {
 	azureDefaults := constants.GetCloudDefaults().Azure
 
 	// todo review defaults and update descriptions
-	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "email address for let's encrypt certificate notifications (required)")
+	createCmd.Flags().String("alerts-email", "", "email address for let's encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
-	createCmd.Flags().BoolVar(&ciFlag, "ci", false, "if running kubefirst in ci, set this flag to disable interactive features")
-	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "eastus", "the Azure region to provision infrastructure in")
-	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
-	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
-	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", azureDefaults.NodeCount, "the node count for the cluster")
-	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", azureDefaults.InstanceSize, "the instance size of the cluster to create")
-	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "azure", fmt.Sprintf("the dns provider - one of: %s", supportedDNSProviders))
-	createCmd.Flags().StringVar(&dnsAzureResourceGroup, "dns-azure-resource-group", "", "the name of the resource group where the DNS Zone exists. If not set, the first matching zone will be used")
-	createCmd.Flags().StringVar(&subdomainNameFlag, "subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
-	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "the Azure/Cloudflare DNS hosted zone name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
+	createCmd.Flags().Bool("ci", false, "if running kubefirst in ci, set this flag to disable interactive features")
+	createCmd.Flags().String("cloud-region", "eastus", "the Azure region to provision infrastructure in")
+	createCmd.Flags().String("cluster-name", "kubefirst", "the name of the cluster to create")
+	createCmd.Flags().String("cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().String("node-count", azureDefaults.NodeCount, "the node count for the cluster")
+	createCmd.Flags().String("node-type", azureDefaults.InstanceSize, "the instance size of the cluster to create")
+	createCmd.Flags().String("dns-provider", "azure", fmt.Sprintf("the dns provider - one of: %s", supportedDNSProviders))
+	createCmd.Flags().String("dns-azure-resource-group", "", "the name of the resource group where the DNS Zone exists. If not set, the first matching zone will be used")
+	createCmd.Flags().String("subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
+	createCmd.Flags().String("domain-name", "", "the Azure/Cloudflare DNS hosted zone name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")
-	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("the git provider - one of: %s", supportedGitProviders))
-	createCmd.Flags().StringVar(&gitProtocolFlag, "git-protocol", "ssh", fmt.Sprintf("the git protocol - one of: %s", supportedGitProtocolOverride))
-	createCmd.Flags().StringVar(&githubOrgFlag, "github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using github")
-	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
-	createCmd.Flags().StringVar(&gitopsTemplateBranchFlag, "gitops-template-branch", "", "the branch to clone for the gitops-template repository")
-	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
-	createCmd.Flags().StringVar(&installCatalogApps, "install-catalog-apps", "", "comma separated values to install after provision")
-	createCmd.Flags().BoolVar(&useTelemetryFlag, "use-telemetry", true, "whether to emit telemetry")
-	createCmd.Flags().BoolVar(&forceDestroyFlag, "force-destroy", false, "allows force destruction on objects (helpful for test environments, defaults to false)")
-	createCmd.Flags().BoolVar(&installKubefirstProFlag, "install-kubefirst-pro", true, "whether or not to install kubefirst pro")
+	createCmd.Flags().String("git-provider", "github", fmt.Sprintf("the git provider - one of: %s", supportedGitProviders))
+	createCmd.Flags().String("git-protocol", "ssh", fmt.Sprintf("the git protocol - one of: %s", supportedGitProtocolOverride))
+	createCmd.Flags().String("github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using github")
+	createCmd.Flags().String("gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
+	createCmd.Flags().String("gitops-template-branch", "", "the branch to clone for the gitops-template repository")
+	createCmd.Flags().String("gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
+	createCmd.Flags().String("install-catalog-apps", "", "comma separated values to install after provision")
+	createCmd.Flags().Bool("use-telemetry", true, "whether to emit telemetry")
+	createCmd.Flags().Bool("force-destroy", false, "allows force destruction on objects (helpful for test environments, defaults to false)")
+	createCmd.Flags().Bool("install-kubefirst-pro", true, "whether or not to install kubefirst pro")
 
 	return createCmd
 }
@@ -134,9 +106,9 @@ func RootCredentials() *cobra.Command {
 		RunE:  common.GetRootCredentials,
 	}
 
-	authCmd.Flags().BoolVar(&copyArgoCDPasswordToClipboardFlag, "argocd", false, "copy the argocd password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyKbotPasswordToClipboardFlag, "kbot", false, "copy the kbot password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyVaultPasswordToClipboardFlag, "vault", false, "copy the vault password to the clipboard (optional)")
+	authCmd.Flags().Bool("argocd", false, "copy the argocd password to the clipboard (optional)")
+	authCmd.Flags().Bool("kbot", false, "copy the kbot password to the clipboard (optional)")
+	authCmd.Flags().Bool("vault", false, "copy the vault password to the clipboard (optional)")
 
 	return authCmd
 }

--- a/cmd/azure/create.go
+++ b/cmd/azure/create.go
@@ -65,7 +65,7 @@ func createAzure(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	utilities.CreateK1ClusterDirectory(clusterNameFlag)
+	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
 
 	gitAuth, err := gitShim.ValidateGitCredentials(cliFlags.GitProvider, cliFlags.GithubOrg, cliFlags.GitlabGroup)
 	if err != nil {
@@ -79,7 +79,7 @@ func createAzure(cmd *cobra.Command, _ []string) error {
 		newTeamNames := []string{"admins", "developers"}
 
 		initGitParameters := gitShim.GitInitParameters{
-			GitProvider:  gitProviderFlag,
+			GitProvider:  cliFlags.GitProvider,
 			GitToken:     gitAuth.Token,
 			GitOwner:     gitAuth.Owner,
 			Repositories: newRepositoryNames,

--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -16,32 +16,6 @@ import (
 )
 
 var (
-	// Create
-	alertsEmailFlag          string
-	ciFlag                   bool
-	cloudRegionFlag          string
-	clusterNameFlag          string
-	clusterTypeFlag          string
-	dnsProviderFlag          string
-	subdomainNameFlag        string
-	domainNameFlag           string
-	githubOrgFlag            string
-	gitlabGroupFlag          string
-	gitProviderFlag          string
-	gitProtocolFlag          string
-	gitopsTemplateURLFlag    string
-	gitopsTemplateBranchFlag string
-	useTelemetryFlag         bool
-	nodeTypeFlag             string
-	nodeCountFlag            string
-	installCatalogApps       string
-	installKubefirstProFlag  bool
-
-	// RootCredentials
-	copyArgoCDPasswordToClipboardFlag bool
-	copyKbotPasswordToClipboardFlag   bool
-	copyVaultPasswordToClipboardFlag  bool
-
 	// Supported providers
 	supportedDNSProviders = []string{"civo", "cloudflare"}
 	supportedGitProviders = []string{"github", "gitlab"}
@@ -93,27 +67,27 @@ func Create() *cobra.Command {
 	civoDefaults := constants.GetCloudDefaults().Civo
 
 	// todo review defaults and update descriptions
-	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "Email address for Let's Encrypt certificate notifications (required)")
+	createCmd.Flags().String("alerts-email", "", "Email address for Let's Encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
-	createCmd.Flags().BoolVar(&ciFlag, "ci", false, "If running Kubefirst in CI, set this flag to disable interactive features")
-	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "NYC1", "The Civo region to provision infrastructure in")
-	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "The name of the cluster to create")
-	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "The type of cluster to create (i.e. mgmt|workload)")
-	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", civoDefaults.NodeCount, "The node count for the cluster")
-	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", civoDefaults.InstanceSize, "The instance size of the cluster to create")
-	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "civo", fmt.Sprintf("The DNS provider - one of: %s", supportedDNSProviders))
-	createCmd.Flags().StringVar(&subdomainNameFlag, "subdomain", "", "The subdomain to use for DNS records (Cloudflare)")
-	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "The Civo DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
+	createCmd.Flags().Bool("ci", false, "If running Kubefirst in CI, set this flag to disable interactive features")
+	createCmd.Flags().String("cloud-region", "NYC1", "The Civo region to provision infrastructure in")
+	createCmd.Flags().String("cluster-name", "kubefirst", "The name of the cluster to create")
+	createCmd.Flags().String("cluster-type", "mgmt", "The type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().String("node-count", civoDefaults.NodeCount, "The node count for the cluster")
+	createCmd.Flags().String("node-type", civoDefaults.InstanceSize, "The instance size of the cluster to create")
+	createCmd.Flags().String("dns-provider", "civo", fmt.Sprintf("The DNS provider - one of: %s", supportedDNSProviders))
+	createCmd.Flags().String("subdomain", "", "The subdomain to use for DNS records (Cloudflare)")
+	createCmd.Flags().String("domain-name", "", "The Civo DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")
-	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("The git provider - one of: %s", supportedGitProviders))
-	createCmd.Flags().StringVar(&gitProtocolFlag, "git-protocol", "ssh", fmt.Sprintf("The git protocol - one of: %s", supportedGitProtocolOverride))
-	createCmd.Flags().StringVar(&githubOrgFlag, "github-org", "", "The GitHub organization for the new GitOps and Metaphor repositories - required if using GitHub")
-	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "The GitLab group for the new GitOps and Metaphor projects - required if using GitLab")
-	createCmd.Flags().StringVar(&gitopsTemplateBranchFlag, "gitops-template-branch", "", "The branch to clone for the gitops-template repository")
-	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/konstructio/gitops-template.git", "The fully qualified URL to the gitops-template repository to clone")
-	createCmd.Flags().StringVar(&installCatalogApps, "install-catalog-apps", "", "Comma separated values to install after provision")
-	createCmd.Flags().BoolVar(&useTelemetryFlag, "use-telemetry", true, "Whether to emit telemetry")
-	createCmd.Flags().BoolVar(&installKubefirstProFlag, "install-kubefirst-pro", true, "Whether or not to install Kubefirst Pro")
+	createCmd.Flags().String("git-provider", "github", fmt.Sprintf("The git provider - one of: %s", supportedGitProviders))
+	createCmd.Flags().String("git-protocol", "ssh", fmt.Sprintf("The git protocol - one of: %s", supportedGitProtocolOverride))
+	createCmd.Flags().String("github-org", "", "The GitHub organization for the new GitOps and Metaphor repositories - required if using GitHub")
+	createCmd.Flags().String("gitlab-group", "", "The GitLab group for the new GitOps and Metaphor projects - required if using GitLab")
+	createCmd.Flags().String("gitops-template-branch", "", "The branch to clone for the gitops-template repository")
+	createCmd.Flags().String("gitops-template-url", "https://github.com/konstructio/gitops-template.git", "The fully qualified URL to the gitops-template repository to clone")
+	createCmd.Flags().String("install-catalog-apps", "", "Comma separated values to install after provision")
+	createCmd.Flags().Bool("use-telemetry", true, "Whether to emit telemetry")
+	createCmd.Flags().Bool("install-kubefirst-pro", true, "Whether or not to install Kubefirst Pro")
 
 	return createCmd
 }
@@ -138,7 +112,7 @@ func Quota() *cobra.Command {
 		RunE:  evalCivoQuota,
 	}
 
-	quotaCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "NYC1", "The Civo region to monitor quotas in")
+	quotaCmd.Flags().String("cloud-region", "NYC1", "The Civo region to monitor quotas in")
 
 	return quotaCmd
 }
@@ -151,9 +125,9 @@ func RootCredentials() *cobra.Command {
 		RunE:  common.GetRootCredentials,
 	}
 
-	authCmd.Flags().BoolVar(&copyArgoCDPasswordToClipboardFlag, "argocd", false, "Copy the ArgoCD password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyKbotPasswordToClipboardFlag, "kbot", false, "Copy the Kbot password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyVaultPasswordToClipboardFlag, "vault", false, "Copy the Vault password to the clipboard (optional)")
+	authCmd.Flags().Bool("argocd", false, "Copy the ArgoCD password to the clipboard (optional)")
+	authCmd.Flags().Bool("kbot", false, "Copy the Kbot password to the clipboard (optional)")
+	authCmd.Flags().Bool("vault", false, "Copy the Vault password to the clipboard (optional)")
 
 	return authCmd
 }

--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -39,7 +39,7 @@ func createCivo(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("catalog apps validation failed: %w", err)
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider)
+	err = ValidateProvidedFlags(cliFlags.GitProvider, cliFlags.DNSProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("failed to validate provided flags: %w", err)
@@ -47,7 +47,7 @@ func createCivo(cmd *cobra.Command, _ []string) error {
 
 	// If cluster setup is complete, return
 
-	utilities.CreateK1ClusterDirectory(clusterNameFlag)
+	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
 
 	gitAuth, err := gitShim.ValidateGitCredentials(cliFlags.GitProvider, cliFlags.GithubOrg, cliFlags.GitlabGroup)
 	if err != nil {
@@ -101,7 +101,7 @@ func createCivo(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func ValidateProvidedFlags(gitProvider string) error {
+func ValidateProvidedFlags(gitProvider, dnsProvider string) error {
 	progress.AddStep("Validate provided flags")
 
 	if os.Getenv("CIVO_TOKEN") == "" {
@@ -109,7 +109,7 @@ func ValidateProvidedFlags(gitProvider string) error {
 	}
 
 	// Validate required environment variables for dns provider
-	if dnsProviderFlag == "cloudflare" {
+	if dnsProvider == "cloudflare" {
 		if os.Getenv("CF_API_TOKEN") == "" {
 			return fmt.Errorf("your CF_API_TOKEN environment variable is not set. Please set and try again")
 		}

--- a/cmd/digitalocean/command.go
+++ b/cmd/digitalocean/command.go
@@ -16,32 +16,6 @@ import (
 )
 
 var (
-	// Create
-	alertsEmailFlag          string
-	ciFlag                   bool
-	cloudRegionFlag          string
-	clusterNameFlag          string
-	clusterTypeFlag          string
-	dnsProviderFlag          string
-	domainNameFlag           string
-	subdomainNameFlag        string
-	githubOrgFlag            string
-	gitlabGroupFlag          string
-	gitProviderFlag          string
-	gitProtocolFlag          string
-	gitopsTemplateURLFlag    string
-	gitopsTemplateBranchFlag string
-	useTelemetryFlag         bool
-	nodeTypeFlag             string
-	nodeCountFlag            string
-	installCatalogApps       string
-	installKubefirstProFlag  bool
-
-	// RootCredentials
-	copyArgoCDPasswordToClipboardFlag bool
-	copyKbotPasswordToClipboardFlag   bool
-	copyVaultPasswordToClipboardFlag  bool
-
 	// Supported providers
 	supportedDNSProviders = []string{"digitalocean", "cloudflare"}
 	supportedGitProviders = []string{"github", "gitlab"}
@@ -85,27 +59,27 @@ func Create() *cobra.Command {
 	doDefaults := constants.GetCloudDefaults().DigitalOcean
 
 	// todo review defaults and update descriptions
-	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "email address for let's encrypt certificate notifications (required)")
+	createCmd.Flags().String("alerts-email", "", "email address for let's encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
-	createCmd.Flags().BoolVar(&ciFlag, "ci", false, "if running Kubefirst in CI, set this flag to disable interactive features")
-	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "nyc3", "the DigitalOcean region to provision infrastructure in")
-	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
-	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
-	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", doDefaults.NodeCount, "the node count for the cluster")
-	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", doDefaults.InstanceSize, "the instance size of the cluster to create")
-	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "digitalocean", fmt.Sprintf("the dns provider - one of: %q", supportedDNSProviders))
-	createCmd.Flags().StringVar(&subdomainNameFlag, "subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
-	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "the DigitalOcean DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
+	createCmd.Flags().Bool("ci", false, "if running Kubefirst in CI, set this flag to disable interactive features")
+	createCmd.Flags().String("cloud-region", "nyc3", "the DigitalOcean region to provision infrastructure in")
+	createCmd.Flags().String("cluster-name", "kubefirst", "the name of the cluster to create")
+	createCmd.Flags().String("cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().String("node-count", doDefaults.NodeCount, "the node count for the cluster")
+	createCmd.Flags().String("node-type", doDefaults.InstanceSize, "the instance size of the cluster to create")
+	createCmd.Flags().String("dns-provider", "digitalocean", fmt.Sprintf("the dns provider - one of: %q", supportedDNSProviders))
+	createCmd.Flags().String("subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
+	createCmd.Flags().String("domain-name", "", "the DigitalOcean DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")
-	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("the git provider - one of: %q", supportedGitProviders))
-	createCmd.Flags().StringVar(&gitProtocolFlag, "git-protocol", "ssh", fmt.Sprintf("the git protocol - one of: %q", supportedGitProtocolOverride))
-	createCmd.Flags().StringVar(&githubOrgFlag, "github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using GitHub")
-	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using GitLab")
-	createCmd.Flags().StringVar(&gitopsTemplateBranchFlag, "gitops-template-branch", "", "the branch to clone for the gitops-template repository")
-	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
-	createCmd.Flags().StringVar(&installCatalogApps, "install-catalog-apps", "", "comma separated values to install after provision")
-	createCmd.Flags().BoolVar(&useTelemetryFlag, "use-telemetry", true, "whether to emit telemetry")
-	createCmd.Flags().BoolVar(&installKubefirstProFlag, "install-kubefirst-pro", true, "whether or not to install Kubefirst Pro")
+	createCmd.Flags().String("git-provider", "github", fmt.Sprintf("the git provider - one of: %q", supportedGitProviders))
+	createCmd.Flags().String("git-protocol", "ssh", fmt.Sprintf("the git protocol - one of: %q", supportedGitProtocolOverride))
+	createCmd.Flags().String("github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using GitHub")
+	createCmd.Flags().String("gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using GitLab")
+	createCmd.Flags().String("gitops-template-branch", "", "the branch to clone for the gitops-template repository")
+	createCmd.Flags().String("gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
+	createCmd.Flags().String("install-catalog-apps", "", "comma separated values to install after provision")
+	createCmd.Flags().Bool("use-telemetry", true, "whether to emit telemetry")
+	createCmd.Flags().Bool("install-kubefirst-pro", true, "whether or not to install Kubefirst Pro")
 
 	return createCmd
 }
@@ -130,9 +104,9 @@ func RootCredentials() *cobra.Command {
 		RunE:  common.GetRootCredentials,
 	}
 
-	authCmd.Flags().BoolVar(&copyArgoCDPasswordToClipboardFlag, "argocd", false, "copy the ArgoCD password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyKbotPasswordToClipboardFlag, "kbot", false, "copy the kbot password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyVaultPasswordToClipboardFlag, "vault", false, "copy the vault password to the clipboard (optional)")
+	authCmd.Flags().Bool("argocd", false, "copy the ArgoCD password to the clipboard (optional)")
+	authCmd.Flags().Bool("kbot", false, "copy the kbot password to the clipboard (optional)")
+	authCmd.Flags().Bool("vault", false, "copy the vault password to the clipboard (optional)")
 
 	return authCmd
 }

--- a/cmd/digitalocean/create.go
+++ b/cmd/digitalocean/create.go
@@ -44,7 +44,7 @@ func createDigitalocean(cmd *cobra.Command, _ []string) error {
 		return errors.New("catalog did not pass a validation check")
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider)
+	err = ValidateProvidedFlags(cliFlags.GitProvider, cliFlags.DNSProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("failed to validate provided flags: %w", err)
@@ -58,7 +58,7 @@ func createDigitalocean(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	utilities.CreateK1ClusterDirectory(clusterNameFlag)
+	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
 
 	gitAuth, err := gitShim.ValidateGitCredentials(cliFlags.GitProvider, cliFlags.GithubOrg, cliFlags.GitlabGroup)
 	if err != nil {
@@ -110,11 +110,11 @@ func createDigitalocean(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func ValidateProvidedFlags(gitProvider string) error {
+func ValidateProvidedFlags(gitProvider, dnsProvider string) error {
 	progress.AddStep("Validate provided flags")
 
 	// Validate required environment variables for dns provider
-	if dnsProviderFlag == "cloudflare" {
+	if dnsProvider == "cloudflare" {
 		if os.Getenv("CF_API_TOKEN") == "" {
 			return fmt.Errorf("your CF_API_TOKEN environment variable is not set. Please set and try again")
 		}

--- a/cmd/google/command.go
+++ b/cmd/google/command.go
@@ -16,34 +16,6 @@ import (
 )
 
 var (
-	// Create
-	alertsEmailFlag          string
-	ciFlag                   bool
-	cloudRegionFlag          string
-	clusterNameFlag          string
-	clusterTypeFlag          string
-	dnsProviderFlag          string
-	domainNameFlag           string
-	subdomainNameFlag        string
-	googleProjectFlag        string
-	githubOrgFlag            string
-	gitlabGroupFlag          string
-	gitProviderFlag          string
-	gitProtocolFlag          string
-	gitopsTemplateURLFlag    string
-	gitopsTemplateBranchFlag string
-	useTelemetryFlag         bool
-	forceDestroyFlag         bool
-	nodeTypeFlag             string
-	nodeCountFlag            string
-	installCatalogApps       string
-	installKubefirstProFlag  bool
-
-	// RootCredentials
-	copyArgoCDPasswordToClipboardFlag bool
-	copyKbotPasswordToClipboardFlag   bool
-	copyVaultPasswordToClipboardFlag  bool
-
 	// Supported providers
 	supportedDNSProviders = []string{"google", "cloudflare"}
 	supportedGitProviders = []string{"github", "gitlab"}
@@ -88,30 +60,30 @@ func Create() *cobra.Command {
 	googleDefaults := constants.GetCloudDefaults().Google
 
 	// todo review defaults and update descriptions
-	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "email address for let's encrypt certificate notifications (required)")
+	createCmd.Flags().String("alerts-email", "", "email address for let's encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
-	createCmd.Flags().BoolVar(&ciFlag, "ci", false, "if running kubefirst in ci, set this flag to disable interactive features")
-	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "us-east1", "the GCP region to provision infrastructure in")
-	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
-	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
-	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", googleDefaults.NodeCount, "the node count for the cluster")
-	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", googleDefaults.InstanceSize, "the instance size of the cluster to create")
-	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "google", fmt.Sprintf("the dns provider - one of: %q", supportedDNSProviders))
-	createCmd.Flags().StringVar(&subdomainNameFlag, "subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
-	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "the GCP DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
+	createCmd.Flags().Bool("ci", false, "if running kubefirst in ci, set this flag to disable interactive features")
+	createCmd.Flags().String("cloud-region", "us-east1", "the GCP region to provision infrastructure in")
+	createCmd.Flags().String("cluster-name", "kubefirst", "the name of the cluster to create")
+	createCmd.Flags().String("cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().String("node-count", googleDefaults.NodeCount, "the node count for the cluster")
+	createCmd.Flags().String("node-type", googleDefaults.InstanceSize, "the instance size of the cluster to create")
+	createCmd.Flags().String("dns-provider", "google", fmt.Sprintf("the dns provider - one of: %q", supportedDNSProviders))
+	createCmd.Flags().String("subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
+	createCmd.Flags().String("domain-name", "", "the GCP DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")
-	createCmd.Flags().StringVar(&googleProjectFlag, "google-project", "", "google project id (required)")
+	createCmd.Flags().String("google-project", "", "google project id (required)")
 	createCmd.MarkFlagRequired("google-project")
-	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("the git provider - one of: %q", supportedGitProviders))
-	createCmd.Flags().StringVar(&gitProtocolFlag, "git-protocol", "ssh", fmt.Sprintf("the git protocol - one of: %q", supportedGitProtocolOverride))
-	createCmd.Flags().StringVar(&githubOrgFlag, "github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using github")
-	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
-	createCmd.Flags().StringVar(&gitopsTemplateBranchFlag, "gitops-template-branch", "", "the branch to clone for the gitops-template repository")
-	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
-	createCmd.Flags().StringVar(&installCatalogApps, "install-catalog-apps", "", "comma separated values to install after provision")
-	createCmd.Flags().BoolVar(&useTelemetryFlag, "use-telemetry", true, "whether to emit telemetry")
-	createCmd.Flags().BoolVar(&forceDestroyFlag, "force-destroy", false, "allows force destruction on objects (helpful for test environments, defaults to false)")
-	createCmd.Flags().BoolVar(&installKubefirstProFlag, "install-kubefirst-pro", true, "whether or not to install kubefirst pro")
+	createCmd.Flags().String("git-provider", "github", fmt.Sprintf("the git provider - one of: %q", supportedGitProviders))
+	createCmd.Flags().String("git-protocol", "ssh", fmt.Sprintf("the git protocol - one of: %q", supportedGitProtocolOverride))
+	createCmd.Flags().String("github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using github")
+	createCmd.Flags().String("gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
+	createCmd.Flags().String("gitops-template-branch", "", "the branch to clone for the gitops-template repository")
+	createCmd.Flags().String("gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
+	createCmd.Flags().String("install-catalog-apps", "", "comma separated values to install after provision")
+	createCmd.Flags().Bool("use-telemetry", true, "whether to emit telemetry")
+	createCmd.Flags().Bool("force-destroy", false, "allows force destruction on objects (helpful for test environments, defaults to false)")
+	createCmd.Flags().Bool("install-kubefirst-pro", true, "whether or not to install kubefirst pro")
 
 	return createCmd
 }
@@ -136,9 +108,9 @@ func RootCredentials() *cobra.Command {
 		RunE:  common.GetRootCredentials,
 	}
 
-	authCmd.Flags().BoolVar(&copyArgoCDPasswordToClipboardFlag, "argocd", false, "copy the ArgoCD password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyKbotPasswordToClipboardFlag, "kbot", false, "copy the kbot password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyVaultPasswordToClipboardFlag, "vault", false, "copy the vault password to the clipboard (optional)")
+	authCmd.Flags().Bool("argocd", false, "copy the ArgoCD password to the clipboard (optional)")
+	authCmd.Flags().Bool("kbot", false, "copy the kbot password to the clipboard (optional)")
+	authCmd.Flags().Bool("vault", false, "copy the vault password to the clipboard (optional)")
 
 	return authCmd
 }

--- a/cmd/google/create.go
+++ b/cmd/google/create.go
@@ -53,7 +53,7 @@ func createGoogle(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("cluster setup is complete: %w", err)
 	}
 
-	utilities.CreateK1ClusterDirectory(clusterNameFlag)
+	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
 
 	gitAuth, err := gitShim.ValidateGitCredentials(cliFlags.GitProvider, cliFlags.GithubOrg, cliFlags.GitlabGroup)
 	if err != nil {
@@ -67,7 +67,7 @@ func createGoogle(cmd *cobra.Command, _ []string) error {
 		newTeamNames := []string{"admins", "developers"}
 
 		initGitParameters := gitShim.GitInitParameters{
-			GitProvider:  gitProviderFlag,
+			GitProvider:  cliFlags.GitProvider,
 			GitToken:     gitAuth.Token,
 			GitOwner:     gitAuth.Owner,
 			Repositories: newRepositoryNames,

--- a/cmd/k3d/command.go
+++ b/cmd/k3d/command.go
@@ -14,28 +14,6 @@ import (
 )
 
 var (
-	// Create
-	applicationNameFlag      string
-	applicationNamespaceFlag string
-	ciFlag                   bool
-	cloudRegionFlag          string
-	clusterNameFlag          string
-	clusterTypeFlag          string
-	githubUserFlag           string
-	githubOrgFlag            string
-	gitlabGroupFlag          string
-	gitProviderFlag          string
-	gitProtocolFlag          string
-	gitopsTemplateURLFlag    string
-	gitopsTemplateBranchFlag string
-	useTelemetryFlag         bool
-	installCatalogApps       string
-
-	// RootCredentials
-	copyArgoCDPasswordToClipboardFlag bool
-	copyKbotPasswordToClipboardFlag   bool
-	copyVaultPasswordToClipboardFlag  bool
-
 	// Supported git providers
 	supportedGitProviders = []string{"github", "gitlab"}
 
@@ -86,18 +64,17 @@ func Create() *cobra.Command {
 	}
 
 	// todo review defaults and update descriptions
-	createCmd.Flags().BoolVar(&ciFlag, "ci", false, "if running kubefirst in ci, set this flag to disable interactive features")
-	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
-	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
-	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("the git provider - one of: %q", supportedGitProviders))
-	createCmd.Flags().StringVar(&gitProtocolFlag, "git-protocol", "ssh", fmt.Sprintf("the git protocol - one of: %q", supportedGitProtocolOverride))
-	createCmd.Flags().StringVar(&githubUserFlag, "github-user", "", "the GitHub user for the new gitops and metaphor repositories - this cannot be used with --github-org")
-	createCmd.Flags().StringVar(&githubOrgFlag, "github-org", "", "the GitHub organization for the new gitops and metaphor repositories - this cannot be used with --github-user")
-	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
-	createCmd.Flags().StringVar(&gitopsTemplateBranchFlag, "gitops-template-branch", "", "the branch to clone for the gitops-template repository")
-	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
-	createCmd.Flags().StringVar(&installCatalogApps, "install-catalog-apps", "", "comma separated values of catalog apps to install after provision")
-	createCmd.Flags().BoolVar(&useTelemetryFlag, "use-telemetry", true, "whether to emit telemetry")
+	createCmd.Flags().Bool("ci", false, "if running kubefirst in ci, set this flag to disable interactive features")
+	createCmd.Flags().String("cluster-name", "kubefirst", "the name of the cluster to create")
+	createCmd.Flags().String("cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().String("git-provider", "github", fmt.Sprintf("the git provider - one of: %q", supportedGitProviders))
+	createCmd.Flags().String("git-protocol", "ssh", fmt.Sprintf("the git protocol - one of: %q", supportedGitProtocolOverride))
+	createCmd.Flags().String("github-org", "", "the GitHub organization for the new gitops and metaphor repositories")
+	createCmd.Flags().String("gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
+	createCmd.Flags().String("gitops-template-branch", "", "the branch to clone for the gitops-template repository")
+	createCmd.Flags().String("gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
+	createCmd.Flags().String("install-catalog-apps", "", "comma separated values of catalog apps to install after provision")
+	createCmd.Flags().Bool("use-telemetry", true, "whether to emit telemetry")
 
 	return createCmd
 }
@@ -121,9 +98,9 @@ func MkCert() *cobra.Command {
 		RunE:  mkCert,
 	}
 
-	mkCertCmd.Flags().StringVar(&applicationNameFlag, "application", "", "the name of the application (required)")
+	mkCertCmd.Flags().String("application", "", "the name of the application (required)")
 	mkCertCmd.MarkFlagRequired("application")
-	mkCertCmd.Flags().StringVar(&applicationNamespaceFlag, "namespace", "", "the application namespace (required)")
+	mkCertCmd.Flags().String("namespace", "", "the application namespace (required)")
 	mkCertCmd.MarkFlagRequired("namespace")
 
 	return mkCertCmd
@@ -137,9 +114,9 @@ func RootCredentials() *cobra.Command {
 		RunE:  getK3dRootCredentials,
 	}
 
-	authCmd.Flags().BoolVar(&copyArgoCDPasswordToClipboardFlag, "argocd", false, "copy the ArgoCD password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyKbotPasswordToClipboardFlag, "kbot", false, "copy the kbot password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyVaultPasswordToClipboardFlag, "vault", false, "copy the vault password to the clipboard (optional)")
+	authCmd.Flags().Bool("argocd", false, "copy the ArgoCD password to the clipboard (optional)")
+	authCmd.Flags().Bool("kbot", false, "copy the kbot password to the clipboard (optional)")
+	authCmd.Flags().Bool("vault", false, "copy the vault password to the clipboard (optional)")
 
 	return authCmd
 }

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -64,7 +64,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to get ci flag: %w", err)
 	}
 
-	cliFlags, err := utilities.GetFlags(cmd, "google")
+	cliFlags, err := utilities.GetFlags(cmd, "k3d")
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("failed to get flags: %w", err)

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -60,68 +60,20 @@ import (
 func runK3d(cmd *cobra.Command, _ []string) error {
 	ciFlag, err := cmd.Flags().GetBool("ci")
 	if err != nil {
-		return fmt.Errorf("failed to get 'ci' flag: %w", err)
+		progress.Error(err.Error())
+		return fmt.Errorf("failed to get ci flag: %w", err)
 	}
 
-	clusterNameFlag, err := cmd.Flags().GetString("cluster-name")
+	cliFlags, err := utilities.GetFlags(cmd, "google")
 	if err != nil {
-		return fmt.Errorf("failed to get 'cluster-name' flag: %w", err)
+		progress.Error(err.Error())
+		return fmt.Errorf("failed to get flags: %w", err)
 	}
 
-	clusterTypeFlag, err := cmd.Flags().GetString("cluster-type")
-	if err != nil {
-		return fmt.Errorf("failed to get 'cluster-type' flag: %w", err)
-	}
-
-	githubOrgFlag, err := cmd.Flags().GetString("github-org")
-	if err != nil {
-		return fmt.Errorf("failed to get 'github-org' flag: %w", err)
-	}
-
-	githubUserFlag, err := cmd.Flags().GetString("github-user")
-	if err != nil {
-		return fmt.Errorf("failed to get 'github-user' flag: %w", err)
-	}
-
-	gitlabGroupFlag, err := cmd.Flags().GetString("gitlab-group")
-	if err != nil {
-		return fmt.Errorf("failed to get 'gitlab-group' flag: %w", err)
-	}
-
-	gitProviderFlag, err := cmd.Flags().GetString("git-provider")
-	if err != nil {
-		return fmt.Errorf("failed to get 'git-provider' flag: %w", err)
-	}
-
-	gitProtocolFlag, err := cmd.Flags().GetString("git-protocol")
-	if err != nil {
-		return fmt.Errorf("failed to get 'git-protocol' flag: %w", err)
-	}
-
-	gitopsTemplateURLFlag, err := cmd.Flags().GetString("gitops-template-url")
-	if err != nil {
-		return fmt.Errorf("failed to get 'gitops-template-url' flag: %w", err)
-	}
-
-	gitopsTemplateBranchFlag, err := cmd.Flags().GetString("gitops-template-branch")
-	if err != nil {
-		return fmt.Errorf("failed to get 'gitops-template-branch' flag: %w", err)
-	}
-
-	installCatalogAppsFlag, err := cmd.Flags().GetString("install-catalog-apps")
-	if err != nil {
-		return fmt.Errorf("failed to get 'install-catalog-apps' flag: %w", err)
-	}
-
-	useTelemetryFlag, err := cmd.Flags().GetBool("use-telemetry")
-	if err != nil {
-		return fmt.Errorf("failed to get 'use-telemetry' flag: %w", err)
-	}
-
-	utilities.CreateK1ClusterDirectory(clusterNameFlag)
+	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
 	utils.DisplayLogHints()
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(installCatalogAppsFlag)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(cliFlags.InstallCatalogApps)
 	if err != nil {
 		return fmt.Errorf("failed to validate catalog apps: %w", err)
 	}
@@ -130,7 +82,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		return errors.New("catalog apps validation failed")
 	}
 
-	switch gitProviderFlag {
+	switch cliFlags.GitProvider {
 	case "github":
 		key, err := internalssh.GetHostKey("github.com")
 		if err != nil {
@@ -143,10 +95,6 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("known_hosts file does not exist - please run `ssh-keyscan gitlab.com >> ~/.ssh/known_hosts` to remedy: %w", err)
 		}
 		log.Info().Msgf("Host key for gitlab.com: %q", key.Type())
-	}
-
-	if githubOrgFlag != "" && githubUserFlag != "" {
-		return errors.New("only one of --github-user or --github-org can be supplied")
 	}
 
 	err = k8s.CheckForExistingPortForwards(8080, 8200, 9000, 9094)
@@ -164,16 +112,16 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		kubefirstTeam = "false"
 	}
 
-	viper.Set("flags.cluster-name", clusterNameFlag)
+	viper.Set("flags.cluster-name", cliFlags.ClusterName)
 	viper.Set("flags.domain-name", k3d.DomainName)
-	viper.Set("flags.git-provider", gitProviderFlag)
-	viper.Set("flags.git-protocol", gitProtocolFlag)
+	viper.Set("flags.git-provider", cliFlags.GitProvider)
+	viper.Set("flags.git-protocol", cliFlags.GitProtocol)
 	viper.Set("kubefirst.cloud-provider", "k3d")
 	viper.WriteConfig()
 
 	var cGitHost, cGitOwner, cGitUser, cGitToken, containerRegistryHost string
 	var cGitlabOwnerGroupID int
-	switch gitProviderFlag {
+	switch cliFlags.GitProvider {
 	case "github":
 		cGitHost = k3d.GithubHost
 		containerRegistryHost = "ghcr.io"
@@ -205,8 +153,8 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("failed to get GitHub user: %w", err)
 		}
 
-		if githubOrgFlag != "" {
-			cGitOwner = githubOrgFlag
+		if cliFlags.GithubOrg != "" {
+			cGitOwner = cliFlags.GithubOrg
 		} else {
 			cGitOwner = githubUser
 		}
@@ -216,7 +164,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		viper.Set("github.session_token", cGitToken)
 		viper.WriteConfig()
 	case "gitlab":
-		if gitlabGroupFlag == "" {
+		if cliFlags.GitlabGroup == "" {
 			return errors.New("please provide a gitlab group using the --gitlab-group flag")
 		}
 
@@ -230,7 +178,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("failed to verify GitLab token permissions: %w", err)
 		}
 
-		gitlabClient, err := gitlab.NewGitLabClient(cGitToken, gitlabGroupFlag)
+		gitlabClient, err := gitlab.NewGitLabClient(cGitToken, cliFlags.GitlabGroup)
 		if err != nil {
 			return fmt.Errorf("failed to create GitLab client: %w", err)
 		}
@@ -245,18 +193,18 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("unable to get authenticated user info - please make sure GITLAB_TOKEN env var is set: %w", err)
 		}
 		cGitUser = user.Username
-		viper.Set("flags.gitlab-owner", gitlabGroupFlag)
+		viper.Set("flags.gitlab-owner", cliFlags.GitlabGroup)
 		viper.Set("flags.gitlab-owner-group-id", cGitlabOwnerGroupID)
 		viper.Set("gitlab.session_token", cGitToken)
 		viper.WriteConfig()
 	default:
-		return fmt.Errorf("invalid git provider option %q", gitProviderFlag)
+		return fmt.Errorf("invalid git provider option %q", cliFlags.GitProvider)
 	}
 
 	var gitDestDescriptor string
-	switch gitProviderFlag {
+	switch cliFlags.GitProvider {
 	case "github":
-		if githubOrgFlag != "" {
+		if cliFlags.GithubOrg != "" {
 			gitDestDescriptor = "Organization"
 		} else {
 			gitDestDescriptor = "User"
@@ -265,12 +213,12 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		gitDestDescriptor = "Group"
 	}
 
-	config, err := k3d.GetConfig(clusterNameFlag, gitProviderFlag, cGitOwner, gitProtocolFlag)
+	config, err := k3d.GetConfig(cliFlags.ClusterName, cliFlags.GitProvider, cGitOwner, cliFlags.GitProtocol)
 	if err != nil {
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	switch gitProviderFlag {
+	switch cliFlags.GitProvider {
 	case "github":
 		config.GithubToken = cGitToken
 	case "gitlab":
@@ -287,7 +235,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		viper.WriteConfig()
 	}
 
-	segClient, err := segment.InitClient(clusterID, clusterTypeFlag, gitProviderFlag)
+	segClient, err := segment.InitClient(clusterID, cliFlags.ClusterType, cliFlags.GitProvider)
 	if err != nil {
 		return fmt.Errorf("failed to initialize segment client: %w", err)
 	}
@@ -298,29 +246,29 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 
 	switch configs.K1Version {
 	case "development":
-		if strings.Contains(gitopsTemplateURLFlag, "https://github.com/konstructio/gitops-template.git") && gitopsTemplateBranchFlag == "" {
-			gitopsTemplateBranchFlag = "main"
+		if strings.Contains(cliFlags.GitopsTemplateURL, "https://github.com/konstructio/gitops-template.git") && cliFlags.GitopsTemplateBranch == "" {
+			cliFlags.GitopsTemplateBranch = "main"
 		}
 	default:
-		switch gitopsTemplateURLFlag {
+		switch cliFlags.GitopsTemplateURL {
 		case "https://github.com/konstructio/gitops-template.git":
-			if gitopsTemplateBranchFlag == "" {
-				gitopsTemplateBranchFlag = configs.K1Version
+			if cliFlags.GitopsTemplateBranch == "" {
+				cliFlags.GitopsTemplateBranch = configs.K1Version
 			}
 		case "https://github.com/konstructio/gitops-template":
-			if gitopsTemplateBranchFlag == "" {
-				gitopsTemplateBranchFlag = configs.K1Version
+			if cliFlags.GitopsTemplateBranch == "" {
+				cliFlags.GitopsTemplateBranch = configs.K1Version
 			}
 		default:
-			if gitopsTemplateBranchFlag == "" {
+			if cliFlags.GitopsTemplateBranch == "" {
 				return errors.New("must supply gitops-template-branch flag when gitops-template-url is overridden")
 			}
 		}
 	}
 
 	log.Info().Msgf("kubefirst version configs.K1Version: %q", configs.K1Version)
-	log.Info().Msgf("cloning gitops-template repo url: %q", gitopsTemplateURLFlag)
-	log.Info().Msgf("cloning gitops-template repo branch: %q", gitopsTemplateBranchFlag)
+	log.Info().Msgf("cloning gitops-template repo url: %q", cliFlags.GitopsTemplateURL)
+	log.Info().Msgf("cloning gitops-template repo branch: %q", cliFlags.GitopsTemplateBranch)
 
 	atlantisWebhookSecret := viper.GetString("secrets.atlantis-webhook")
 	if atlantisWebhookSecret == "" {
@@ -365,7 +313,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		}
 
 		initGitParameters := gitShim.GitInitParameters{
-			GitProvider:  gitProviderFlag,
+			GitProvider:  cliFlags.GitProvider,
 			GitToken:     cGitToken,
 			GitOwner:     cGitOwner,
 			Repositories: newRepositoryNames,
@@ -431,8 +379,8 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		DomainName:                    k3d.DomainName,
 		AtlantisAllowList:             fmt.Sprintf("%s/%s/*", cGitHost, cGitOwner),
 		AlertsEmail:                   "REMOVE_THIS_VALUE",
-		ClusterName:                   clusterNameFlag,
-		ClusterType:                   clusterTypeFlag,
+		ClusterName:                   cliFlags.ClusterName,
+		ClusterType:                   cliFlags.ClusterType,
 		GithubHost:                    k3d.GithubHost,
 		GitlabHost:                    k3d.GitlabHost,
 		ArgoWorkflowsIngressURL:       fmt.Sprintf("https://argo.%s", k3d.DomainName),
@@ -451,7 +399,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		CloudProvider:                 k3d.CloudProvider,
 	}
 
-	if useTelemetryFlag {
+	if cliFlags.UseTelemetry {
 		gitopsDirectoryTokens.UseTelemetry = "true"
 	} else {
 		gitopsDirectoryTokens.UseTelemetry = "false"
@@ -470,7 +418,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 	if !viper.GetBool("kubefirst-checks.tools-downloaded") {
 		log.Info().Msg("installing kubefirst dependencies")
 
-		err := k3d.DownloadTools(clusterNameFlag, config.GitProvider, cGitOwner, config.ToolsDir, config.GitProtocol)
+		err := k3d.DownloadTools(cliFlags.ClusterName, config.GitProvider, cGitOwner, config.ToolsDir, config.GitProtocol)
 		if err != nil {
 			return fmt.Errorf("failed to download tools: %w", err)
 		}
@@ -484,8 +432,8 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 	progressPrinter.IncrementTracker("preflight-checks")
 
 	metaphorTemplateTokens := k3d.MetaphorTokenValues{
-		ClusterName:                   clusterNameFlag,
-		CloudRegion:                   cloudRegionFlag,
+		ClusterName:                   cliFlags.ClusterName,
+		CloudRegion:                   cliFlags.CloudRegion,
 		ContainerRegistryURL:          fmt.Sprintf("%s/%s/metaphor", containerRegistryHost, cGitOwner),
 		DomainName:                    k3d.DomainName,
 		MetaphorDevelopmentIngressURL: fmt.Sprintf("metaphor-development.%s", k3d.DomainName),
@@ -505,18 +453,18 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		log.Info().Msg("generating your new gitops repository")
 		err := k3d.PrepareGitRepositories(
 			config.GitProvider,
-			clusterNameFlag,
-			clusterTypeFlag,
+			cliFlags.ClusterName,
+			cliFlags.ClusterType,
 			config.DestinationGitopsRepoURL,
 			config.GitopsDir,
-			gitopsTemplateBranchFlag,
-			gitopsTemplateURLFlag,
+			cliFlags.GitopsTemplateBranch,
+			cliFlags.GitopsTemplateURL,
 			config.DestinationMetaphorRepoURL,
 			config.K1Dir,
 			&gitopsDirectoryTokens,
 			config.MetaphorDir,
 			&metaphorTemplateTokens,
-			gitProtocolFlag,
+			cliFlags.GitProtocol,
 			removeAtlantis,
 		)
 		if err != nil {
@@ -582,7 +530,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 			tfEntrypoint := config.GitopsDir + "/terraform/gitlab"
 			tfEnvs := map[string]string{
 				"GITLAB_TOKEN":                 cGitToken,
-				"GITLAB_OWNER":                 gitlabGroupFlag,
+				"GITLAB_OWNER":                 cliFlags.GitlabGroup,
 				"TF_VAR_owner_group_id":        strconv.Itoa(cGitlabOwnerGroupID),
 				"TF_VAR_kbot_ssh_public_key":   viper.GetString("kbot.public-key"),
 				"AWS_ACCESS_KEY_ID":            constants.MinioDefaultUsername,
@@ -601,7 +549,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 				return msg
 			}
 
-			log.Info().Msgf("created git projects and groups for gitlab.com/%s", gitlabGroupFlag)
+			log.Info().Msgf("created git projects and groups for gitlab.com/%s", cliFlags.GitlabGroup)
 			viper.Set("kubefirst-checks.terraform-apply-gitlab", true)
 			viper.WriteConfig()
 			telemetry.SendEvent(segClient, telemetry.GitTerraformApplyCompleted, "")
@@ -633,8 +581,8 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		}
 
 		err = utils.EvalSSHKey(&types.EvalSSHKeyRequest{
-			GitProvider:     gitProviderFlag,
-			GitlabGroupFlag: gitlabGroupFlag,
+			GitProvider:     cliFlags.GitProvider,
+			GitlabGroupFlag: cliFlags.GitlabGroup,
 			GitToken:        cGitToken,
 		})
 		if err != nil {
@@ -688,7 +636,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 
 		log.Info().Msg("Creating k3d cluster")
 
-		err := k3d.ClusterCreate(clusterNameFlag, config.K1Dir, config.K3dClient, config.Kubeconfig)
+		err := k3d.ClusterCreate(cliFlags.ClusterName, config.K1Dir, config.K3dClient, config.Kubeconfig)
 		if err != nil {
 			msg := fmt.Errorf("error creating k3d resources with k3d client %q: %w", config.K3dClient, err)
 			viper.Set("kubefirst-checks.create-k3d-cluster-failed", true)
@@ -743,10 +691,10 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 	}
 
 	containerRegistryAuth := gitShim.ContainerRegistryAuth{
-		GitProvider:           gitProviderFlag,
+		GitProvider:           cliFlags.GitProvider,
 		GitUser:               cGitUser,
 		GitToken:              cGitToken,
-		GitlabGroupFlag:       gitlabGroupFlag,
+		GitlabGroupFlag:       cliFlags.GitlabGroup,
 		GithubOwner:           cGitOwner,
 		ContainerRegistryHost: containerRegistryHost,
 		Clientset:             kcfg.Clientset,
@@ -920,7 +868,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 		}
 
 		log.Info().Msg("applying the registry application to ArgoCD")
-		registryApplicationObject := argocd.GetArgoCDApplicationObject(gitopsRepoURL, fmt.Sprintf("registry/%s", clusterNameFlag))
+		registryApplicationObject := argocd.GetArgoCDApplicationObject(gitopsRepoURL, fmt.Sprintf("registry/%s", cliFlags.ClusterName))
 
 		err = k3d.RestartDeployment(context.Background(), kcfg.Clientset, "argocd", "argocd-applicationset-controller")
 		if err != nil {
@@ -1235,7 +1183,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 
 	utils.SetClusterStatusFlags(k3d.CloudProvider, config.GitProvider)
 
-	cluster := utilities.CreateClusterRecordFromRaw(useTelemetryFlag, cGitOwner, cGitUser, cGitToken, cGitlabOwnerGroupID, gitopsTemplateURLFlag, gitopsTemplateBranchFlag, catalogApps)
+	cluster := utilities.CreateClusterRecordFromRaw(cliFlags.UseTelemetry, cGitOwner, cGitUser, cGitToken, cGitlabOwnerGroupID, cliFlags.GitopsTemplateURL, cliFlags.GitopsTemplateBranch, catalogApps)
 
 	err = utilities.ExportCluster(cluster, kcfg)
 	if err != nil {
@@ -1275,7 +1223,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 	log.Info().Msg("welcome to your new Kubefirst platform running in K3D")
 	time.Sleep(1 * time.Second)
 
-	reports.LocalHandoffScreenV2(clusterNameFlag, gitDestDescriptor, cGitOwner, config, ciFlag)
+	reports.LocalHandoffScreenV2(cliFlags.ClusterName, gitDestDescriptor, cGitOwner, config, ciFlag)
 
 	if ciFlag {
 		progress.Progress.Quit()

--- a/cmd/k3s/command.go
+++ b/cmd/k3s/command.go
@@ -14,39 +14,6 @@ import (
 )
 
 var (
-	// Create
-	// TODO: add ssh key flag to connect on k3s targets
-	alertsEmailFlag          string
-	ciFlag                   bool
-	cloudRegionFlag          string
-	nodeTypeFlag             string
-	nodeCountFlag            string
-	clusterNameFlag          string
-	clusterTypeFlag          string
-	k3sServersPrivateIpsFlag []string
-	k3sServersPublicIpsFlag  []string
-	k3sSSHUserflag           string
-	k3sSSHPrivateKeyflag     string
-	K3sServersArgsFlags      []string
-	dnsProviderFlag          string
-	subdomainNameFlag        string
-	domainNameFlag           string
-	githubOrgFlag            string
-	gitlabGroupFlag          string
-	gitProviderFlag          string
-	gitProtocolFlag          string
-	gitopsTemplateURLFlag    string
-	gitopsTemplateBranchFlag string
-	installCatalogApps       string
-	useTelemetryFlag         bool
-	forceDestroyFlag         bool
-	installKubefirstProFlag  bool
-
-	// RootCredentials
-	copyArgoCDPasswordToClipboardFlag bool
-	copyKbotPasswordToClipboardFlag   bool
-	copyVaultPasswordToClipboardFlag  bool
-
 	// Supported providers
 	supportedDNSProviders = []string{"cloudflare"}
 	supportedGitProviders = []string{"github", "gitlab"}
@@ -81,34 +48,34 @@ func Create() *cobra.Command {
 	}
 
 	// todo review defaults and update descriptions
-	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "email address for let's encrypt certificate notifications (required)")
+	createCmd.Flags().String("alerts-email", "", "email address for let's encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
-	createCmd.Flags().BoolVar(&ciFlag, "ci", false, "if running kubefirst in ci, set this flag to disable interactive features")
-	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "on-premise", "NOT USED, PRESENT FOR COMPATIBILITY ISSUE")
-	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", "on-premise", "NOT USED, PRESENT FOR COMPATIBILITY ISSUE")
-	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", "3", "NOT USED, PRESENT FOR COMPATIBILITY ISSUE")
-	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
-	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
-	createCmd.Flags().StringSliceVar(&k3sServersPrivateIpsFlag, "servers-private-ips", []string{}, "the list of k3s (servers) private ip x.x.x.x,y.y.y.y comma separated  (required)")
+	createCmd.Flags().Bool("ci", false, "if running kubefirst in ci, set this flag to disable interactive features")
+	createCmd.Flags().String("cloud-region", "on-premise", "NOT USED, PRESENT FOR COMPATIBILITY ISSUE")
+	createCmd.Flags().String("node-type", "on-premise", "NOT USED, PRESENT FOR COMPATIBILITY ISSUE")
+	createCmd.Flags().String("node-count", "3", "NOT USED, PRESENT FOR COMPATIBILITY ISSUE")
+	createCmd.Flags().String("cluster-name", "kubefirst", "the name of the cluster to create")
+	createCmd.Flags().String("cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().StringSlice("servers-private-ips", []string{}, "the list of k3s (servers) private ip x.x.x.x,y.y.y.y comma separated  (required)")
 	createCmd.MarkFlagRequired("servers-private-ips")
-	createCmd.Flags().StringSliceVar(&k3sServersPublicIpsFlag, "servers-public-ips", []string{}, "the list of k3s (servers) public ip x.x.x.x,y.y.y.y comma separated  (required)")
-	createCmd.Flags().StringSliceVar(&K3sServersArgsFlags, "servers-args", []string{"--disable traefik", "--write-kubeconfig-mode 644"}, "list of k3s extras args to add to the k3s server installation,comma separated in between quote, if --servers-public-ips <VALUES> --tls-san <VALUES> is added to default --servers-args")
-	createCmd.Flags().StringVar(&k3sSSHUserflag, "ssh-user", "root", "the user used to log into servers with ssh connection")
-	createCmd.Flags().StringVar(&k3sSSHPrivateKeyflag, "ssh-privatekey", "", "the private key used to log into servers with ssh connection")
+	createCmd.Flags().StringSlice("servers-public-ips", []string{}, "the list of k3s (servers) public ip x.x.x.x,y.y.y.y comma separated  (required)")
+	createCmd.Flags().StringSlice("servers-args", []string{"--disable traefik", "--write-kubeconfig-mode 644"}, "list of k3s extras args to add to the k3s server installation,comma separated in between quote, if --servers-public-ips <VALUES> --tls-san <VALUES> is added to default --servers-args")
+	createCmd.Flags().String("ssh-user", "root", "the user used to log into servers with ssh connection")
+	createCmd.Flags().String("ssh-privatekey", "", "the private key used to log into servers with ssh connection")
 	createCmd.MarkFlagRequired("ssh-privatekey")
-	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "cloudflare", fmt.Sprintf("the dns provider - one of: %q", supportedDNSProviders))
-	createCmd.Flags().StringVar(&subdomainNameFlag, "subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
-	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "the cloudProvider DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
-	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("the git provider - one of: %q", supportedGitProviders))
-	createCmd.Flags().StringVar(&gitProtocolFlag, "git-protocol", "ssh", fmt.Sprintf("the git protocol - one of: %q", supportedGitProtocolOverride))
-	createCmd.Flags().StringVar(&githubOrgFlag, "github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using github")
-	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
-	createCmd.Flags().StringVar(&gitopsTemplateBranchFlag, "gitops-template-branch", "", "the branch to clone for the gitops-template repository")
-	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
-	createCmd.Flags().StringVar(&installCatalogApps, "install-catalog-apps", "", "comma separated values to install after provision")
-	createCmd.Flags().BoolVar(&useTelemetryFlag, "use-telemetry", true, "whether to emit telemetry")
-	createCmd.Flags().BoolVar(&forceDestroyFlag, "force-destroy", false, "allows force destruction on objects (helpful for test environments, defaults to false)")
-	createCmd.Flags().BoolVar(&installKubefirstProFlag, "install-kubefirst-pro", true, "whether or not to install kubefirst pro")
+	createCmd.Flags().String("dns-provider", "cloudflare", fmt.Sprintf("the dns provider - one of: %q", supportedDNSProviders))
+	createCmd.Flags().String("subdomain", "", "the subdomain to use for DNS records (Cloudflare)")
+	createCmd.Flags().String("domain-name", "", "the cloudProvider DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
+	createCmd.Flags().String("git-provider", "github", fmt.Sprintf("the git provider - one of: %q", supportedGitProviders))
+	createCmd.Flags().String("git-protocol", "ssh", fmt.Sprintf("the git protocol - one of: %q", supportedGitProtocolOverride))
+	createCmd.Flags().String("github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using github")
+	createCmd.Flags().String("gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
+	createCmd.Flags().String("gitops-template-branch", "", "the branch to clone for the gitops-template repository")
+	createCmd.Flags().String("gitops-template-url", "https://github.com/konstructio/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
+	createCmd.Flags().String("install-catalog-apps", "", "comma separated values to install after provision")
+	createCmd.Flags().Bool("use-telemetry", true, "whether to emit telemetry")
+	createCmd.Flags().Bool("force-destroy", false, "allows force destruction on objects (helpful for test environments, defaults to false)")
+	createCmd.Flags().Bool("install-kubefirst-pro", true, "whether or not to install kubefirst pro")
 
 	return createCmd
 }
@@ -133,9 +100,9 @@ func RootCredentials() *cobra.Command {
 		RunE:  common.GetRootCredentials,
 	}
 
-	authCmd.Flags().BoolVar(&copyArgoCDPasswordToClipboardFlag, "argocd", false, "copy the ArgoCD password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyKbotPasswordToClipboardFlag, "kbot", false, "copy the kbot password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyVaultPasswordToClipboardFlag, "vault", false, "copy the vault password to the clipboard (optional)")
+	authCmd.Flags().Bool("argocd", false, "copy the ArgoCD password to the clipboard (optional)")
+	authCmd.Flags().Bool("kbot", false, "copy the kbot password to the clipboard (optional)")
+	authCmd.Flags().Bool("vault", false, "copy the vault password to the clipboard (optional)")
 
 	return authCmd
 }

--- a/cmd/k3s/create.go
+++ b/cmd/k3s/create.go
@@ -60,7 +60,7 @@ func createK3s(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	utilities.CreateK1ClusterDirectory(clusterNameFlag)
+	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
 
 	gitAuth, err := gitShim.ValidateGitCredentials(cliFlags.GitProvider, cliFlags.GithubOrg, cliFlags.GitlabGroup)
 	if err != nil {
@@ -74,7 +74,7 @@ func createK3s(cmd *cobra.Command, _ []string) error {
 		newTeamNames := []string{"admins", "developers"}
 
 		initGitParameters := gitShim.GitInitParameters{
-			GitProvider:  gitProviderFlag,
+			GitProvider:  cliFlags.GitProvider,
 			GitToken:     gitAuth.Token,
 			GitOwner:     gitAuth.Owner,
 			Repositories: newRepositoryNames,

--- a/cmd/vultr/command.go
+++ b/cmd/vultr/command.go
@@ -16,32 +16,6 @@ import (
 )
 
 var (
-	// Create
-	alertsEmailFlag          string
-	ciFlag                   bool
-	cloudRegionFlag          string
-	clusterNameFlag          string
-	clusterTypeFlag          string
-	dnsProviderFlag          string
-	domainNameFlag           string
-	subdomainNameFlag        string
-	githubOrgFlag            string
-	gitlabGroupFlag          string
-	gitProviderFlag          string
-	gitProtocolFlag          string
-	gitopsTemplateURLFlag    string
-	gitopsTemplateBranchFlag string
-	useTelemetryFlag         bool
-	nodeTypeFlag             string
-	nodeCountFlag            string
-	installCatalogApps       string
-	installKubefirstProFlag  bool
-
-	// RootCredentials
-	copyArgoCDPasswordToClipboardFlag bool
-	copyKbotPasswordToClipboardFlag   bool
-	copyVaultPasswordToClipboardFlag  bool
-
 	// Supported providers
 	supportedDNSProviders = []string{"vultr", "cloudflare"}
 	supportedGitProviders = []string{"github", "gitlab"}
@@ -85,27 +59,27 @@ func Create() *cobra.Command {
 	vultrDefaults := constants.GetCloudDefaults().Vultr
 
 	// todo review defaults and update descriptions
-	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "Email address for Let's Encrypt certificate notifications (required)")
+	createCmd.Flags().String("alerts-email", "", "Email address for Let's Encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
-	createCmd.Flags().BoolVar(&ciFlag, "ci", false, "If running Kubefirst in CI, set this flag to disable interactive features")
-	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "ewr", "The Vultr region to provision infrastructure in")
-	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "The name of the cluster to create")
-	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "The type of cluster to create (i.e. mgmt|workload)")
-	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", vultrDefaults.NodeCount, "The node count for the cluster")
-	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", vultrDefaults.InstanceSize, "The instance size of the cluster to create")
-	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "vultr", fmt.Sprintf("The DNS provider - one of: %s", supportedDNSProviders))
-	createCmd.Flags().StringVar(&subdomainNameFlag, "subdomain", "", "The subdomain to use for DNS records (Cloudflare)")
-	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "The Vultr DNS name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
+	createCmd.Flags().Bool("ci", false, "If running Kubefirst in CI, set this flag to disable interactive features")
+	createCmd.Flags().String("cloud-region", "ewr", "The Vultr region to provision infrastructure in")
+	createCmd.Flags().String("cluster-name", "kubefirst", "The name of the cluster to create")
+	createCmd.Flags().String("cluster-type", "mgmt", "The type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().String("node-count", vultrDefaults.NodeCount, "The node count for the cluster")
+	createCmd.Flags().String("node-type", vultrDefaults.InstanceSize, "The instance size of the cluster to create")
+	createCmd.Flags().String("dns-provider", "vultr", fmt.Sprintf("The DNS provider - one of: %s", supportedDNSProviders))
+	createCmd.Flags().String("subdomain", "", "The subdomain to use for DNS records (Cloudflare)")
+	createCmd.Flags().String("domain-name", "", "The Vultr DNS name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")
-	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("The Git provider - one of: %s", supportedGitProviders))
-	createCmd.Flags().StringVar(&gitProtocolFlag, "git-protocol", "ssh", fmt.Sprintf("The Git protocol - one of: %s", supportedGitProtocolOverride))
-	createCmd.Flags().StringVar(&githubOrgFlag, "github-org", "", "The GitHub organization for the new GitOps and metaphor repositories - required if using GitHub")
-	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "The GitLab group for the new GitOps and metaphor projects - required if using GitLab")
-	createCmd.Flags().StringVar(&gitopsTemplateBranchFlag, "gitops-template-branch", "", "The branch to clone for the GitOps template repository")
-	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/konstructio/gitops-template.git", "The fully qualified URL to the GitOps template repository to clone")
-	createCmd.Flags().StringVar(&installCatalogApps, "install-catalog-apps", "", "Comma separated values to install after provision")
-	createCmd.Flags().BoolVar(&useTelemetryFlag, "use-telemetry", true, "Whether to emit telemetry")
-	createCmd.Flags().BoolVar(&installKubefirstProFlag, "install-kubefirst-pro", true, "Whether or not to install Kubefirst Pro")
+	createCmd.Flags().String("git-provider", "github", fmt.Sprintf("The Git provider - one of: %s", supportedGitProviders))
+	createCmd.Flags().String("git-protocol", "ssh", fmt.Sprintf("The Git protocol - one of: %s", supportedGitProtocolOverride))
+	createCmd.Flags().String("github-org", "", "The GitHub organization for the new GitOps and metaphor repositories - required if using GitHub")
+	createCmd.Flags().String("gitlab-group", "", "The GitLab group for the new GitOps and metaphor projects - required if using GitLab")
+	createCmd.Flags().String("gitops-template-branch", "", "The branch to clone for the GitOps template repository")
+	createCmd.Flags().String("gitops-template-url", "https://github.com/konstructio/gitops-template.git", "The fully qualified URL to the GitOps template repository to clone")
+	createCmd.Flags().String("install-catalog-apps", "", "Comma separated values to install after provision")
+	createCmd.Flags().Bool("use-telemetry", true, "Whether to emit telemetry")
+	createCmd.Flags().Bool("install-kubefirst-pro", true, "Whether or not to install Kubefirst Pro")
 
 	return createCmd
 }
@@ -130,9 +104,9 @@ func RootCredentials() *cobra.Command {
 		RunE:  common.GetRootCredentials,
 	}
 
-	authCmd.Flags().BoolVar(&copyArgoCDPasswordToClipboardFlag, "argocd", false, "Copy the ArgoCD password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyKbotPasswordToClipboardFlag, "kbot", false, "Copy the kbot password to the clipboard (optional)")
-	authCmd.Flags().BoolVar(&copyVaultPasswordToClipboardFlag, "vault", false, "Copy the vault password to the clipboard (optional)")
+	authCmd.Flags().Bool("argocd", false, "Copy the ArgoCD password to the clipboard (optional)")
+	authCmd.Flags().Bool("kbot", false, "Copy the kbot password to the clipboard (optional)")
+	authCmd.Flags().Bool("vault", false, "Copy the vault password to the clipboard (optional)")
 
 	return authCmd
 }

--- a/cmd/vultr/create.go
+++ b/cmd/vultr/create.go
@@ -44,7 +44,7 @@ func createVultr(cmd *cobra.Command, _ []string) error {
 		return errors.New("catalog validation failed")
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider)
+	err = ValidateProvidedFlags(cliFlags.GitProvider, cliFlags.DNSProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("invalid provided flags: %w", err)
@@ -57,7 +57,7 @@ func createVultr(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	utilities.CreateK1ClusterDirectory(clusterNameFlag)
+	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
 
 	gitAuth, err := gitShim.ValidateGitCredentials(cliFlags.GitProvider, cliFlags.GithubOrg, cliFlags.GitlabGroup)
 	if err != nil {
@@ -110,14 +110,14 @@ func createVultr(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func ValidateProvidedFlags(gitProvider string) error {
+func ValidateProvidedFlags(gitProvider, dnsProvider string) error {
 	progress.AddStep("Validate provided flags")
 
 	if os.Getenv("VULTR_API_KEY") == "" {
 		return fmt.Errorf("your VULTR_API_KEY variable is unset - please set it before continuing")
 	}
 
-	if dnsProviderFlag == "cloudflare" {
+	if dnsProvider == "cloudflare" {
 		if os.Getenv("CF_API_TOKEN") == "" {
 			return fmt.Errorf("your CF_API_TOKEN environment variable is not set. Please set and try again")
 		}


### PR DESCRIPTION
## Description

All of the commands had flags that were never used. There's a function to pull them so we're leveraging that instead. 

The `k3d` cluster creation had a `--github-user` flag that was being validated, checked but not handled at all (after validation the program would say: "yep, all good!")

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
