### PR TITLE
Generate app scaffold from CLI

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -7,6 +7,10 @@ See the LICENSE file for more details.
 package cmd
 
 import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/konstructio/kubefirst/internal/generate"
 	"github.com/konstructio/kubefirst/internal/progress"
 	"github.com/spf13/cobra"
 )
@@ -26,19 +30,27 @@ func GenerateCommand() *cobra.Command {
 func generateApp() *cobra.Command {
 	var name string
 	var environments []string
+	var outputPath string
 
 	appScaffoldCmd := &cobra.Command{
 		Use:              "app-scaffold",
 		Short:            "scaffold the gitops application repo",
 		TraverseChildren: true,
-		Run: func(_ *cobra.Command, _ []string) {
-			progress.Success("hello world")
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := generate.AppScaffold(name, environments, outputPath); err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("error scaffolding app: %w", err)
+			}
+
+			progress.Success(fmt.Sprintf("App successfully scaffolded: %s", name))
+			return nil
 		},
 	}
 
 	appScaffoldCmd.Flags().StringVarP(&name, "name", "n", "", "name of the app")
 	appScaffoldCmd.MarkFlagRequired("name")
 	appScaffoldCmd.Flags().StringSliceVar(&environments, "environments", []string{"development", "staging", "production"}, "environment names to create")
+	appScaffoldCmd.Flags().StringVar(&outputPath, "output-path", filepath.Join(".", "registry", "environments"), "location to save generated files")
 
 	return appScaffoldCmd
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2021-2025, Kubefirst
+
+This program is licensed under MIT.
+See the LICENSE file for more details.
+*/
+package cmd
+
+import (
+	"github.com/konstructio/kubefirst/internal/progress"
+	"github.com/spf13/cobra"
+)
+
+func GenerateCommand() *cobra.Command {
+	generateCommand := &cobra.Command{
+		Use:   "generate",
+		Short: "code generator helpers",
+	}
+
+	// wire up new commands
+	generateCommand.AddCommand(generateApp())
+
+	return generateCommand
+}
+
+func generateApp() *cobra.Command {
+	var name string
+	var environments []string
+
+	appScaffoldCmd := &cobra.Command{
+		Use:              "app-scaffold",
+		Short:            "scaffold the gitops application repo",
+		TraverseChildren: true,
+		Run: func(_ *cobra.Command, _ []string) {
+			progress.Success("hello world")
+		},
+	}
+
+	appScaffoldCmd.Flags().StringVarP(&name, "name", "n", "", "name of the app")
+	appScaffoldCmd.MarkFlagRequired("name")
+	appScaffoldCmd.Flags().StringSliceVar(&environments, "environments", []string{"development", "staging", "production"}, "environment names to create")
+
+	return appScaffoldCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ func init() {
 		k3d.LocalCommandAlias(),
 		google.NewCommand(),
 		vultr.NewCommand(),
+		GenerateCommand(),
 		LaunchCommand(),
 		LetsEncryptCommand(),
 		TerraformCommand(),

--- a/internal/generate/files.go
+++ b/internal/generate/files.go
@@ -1,0 +1,36 @@
+package generate
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type Files struct {
+	data map[string]bytes.Buffer
+}
+
+func (f *Files) Add(file string, content bytes.Buffer) {
+	if f.data == nil {
+		f.data = map[string]bytes.Buffer{}
+	}
+
+	f.data[file] = content
+}
+
+func (f *Files) Save(filePrefix string) error {
+	for file, content := range f.data {
+		name := filepath.Join(filePrefix, file)
+
+		if err := os.MkdirAll(filepath.Dir(name), 0o755); err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+
+		if err := os.WriteFile(name, content.Bytes(), 0o644); err != nil {
+			return fmt.Errorf("failed to write file: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/generate/scaffold.go
+++ b/internal/generate/scaffold.go
@@ -1,0 +1,94 @@
+package generate
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+//go:embed scaffold
+var scaffoldFS embed.FS
+
+type ScaffoldData struct {
+	AppName        string
+	DeploymentName string
+	Description    string
+	Environment    string
+	Namespace      string
+}
+
+func AppScaffold(appName string, environments []string, outputPath string) error {
+	for _, env := range environments {
+		files, err := generateAppScaffoldEnvironmentFiles(appName, env)
+		if err != nil {
+			return err
+		}
+
+		if err := files.Save(filepath.Join(outputPath, env)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func generateAppScaffoldEnvironmentFiles(appName, environment string) (*Files, error) {
+	rootDir := "scaffold/"
+
+	tpl, err := template.New("tpl").ParseFS(scaffoldFS, rootDir+"*.yaml", rootDir+"**/*.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create template: %w", err)
+	}
+
+	data := ScaffoldData{
+		AppName:        appName,
+		DeploymentName: fmt.Sprintf("%s-environment-%s", environment, appName),
+		Description:    fmt.Sprintf("%s example application", appName),
+		Environment:    environment,
+		Namespace:      environment,
+	}
+
+	files := &Files{}
+	err = fs.WalkDir(scaffoldFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("error walking directory: %w", err)
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		// Get the file name without the root path
+		file, _ := strings.CutPrefix(path, rootDir)
+
+		// Parse any template variables in the file name
+		fileTpl, err := tpl.Parse(file)
+		if err != nil {
+			return fmt.Errorf("error parsing file name: %w", err)
+		}
+
+		var fileNameOutput bytes.Buffer
+		if err := fileTpl.Execute(&fileNameOutput, data); err != nil {
+			return fmt.Errorf("error executing file name: %w", err)
+		}
+
+		// Parse the contents of the file
+		var fileContent bytes.Buffer
+		if err := tpl.ExecuteTemplate(&fileContent, d.Name(), data); err != nil {
+			return fmt.Errorf("error executing template: %w", err)
+		}
+
+		// Now store everything for output
+		files.Add(fileNameOutput.String(), fileContent)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error walking directory: %w", err)
+	}
+
+	return files, nil
+}

--- a/internal/generate/scaffold/{{ .AppName }}.yaml
+++ b/internal/generate/scaffold/{{ .AppName }}.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "{{ .DeploymentName }}"
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '45'
+spec:
+  project: default
+  source:
+    repoURL: <GITOPS_REPO_URL>
+    path: "registry/environments/{{ .Environment }}/{{ .AppName }}"
+    targetRevision: HEAD
+  destination:
+    name: in-cluster
+    namespace: "{{ .Namespace }}"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/internal/generate/scaffold/{{ .AppName }}/Chart.yaml
+++ b/internal/generate/scaffold/{{ .AppName }}/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+description: "{{ .Description }}"
+name: "{{ .AppName }}"
+type: application
+version: 1.0.0
+dependencies:
+  - name: "{{ .AppName }}"
+    repository: http://chartmuseum.chartmuseum.svc.cluster.local:8080
+    version: 0.0.1-rc.awaiting-ci

--- a/internal/generate/scaffold/{{ .AppName }}/values.yaml
+++ b/internal/generate/scaffold/{{ .AppName }}/values.yaml
@@ -1,0 +1,29 @@
+# This is a generated file. These values may not correspond to your own chart's values
+
+"{{ .AppName }}":
+  annotations: |
+    linkerd.io/inject: "enabled"
+  labels: |
+    mirror.linkerd.io/exported: "true"
+  image:
+    repository: "<CONTAINER_REGISTRY_URL>/{{ .AppName }}"
+  imagePullSecrets:
+    - name: docker-config
+  ingress:
+    className: nginx
+    enabled: true
+    annotations:
+      <CERT_MANAGER_ISSUER_ANNOTATION_1>
+      <CERT_MANAGER_ISSUER_ANNOTATION_2>
+      <CERT_MANAGER_ISSUER_ANNOTATION_3>
+      <CERT_MANAGER_ISSUER_ANNOTATION_4>
+      nginx.ingress.kubernetes.io/service-upstream: "true"
+    hosts:
+      - host: "{{ .AppName }}-{{ .Environment }}.<DOMAIN_NAME>"
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: "{{ .AppName }}-tls"
+        hosts:
+          - "{{ .AppName }}-{{ .Environment }}.<DOMAIN_NAME>"

--- a/internal/generate/scaffold_test.go
+++ b/internal/generate/scaffold_test.go
@@ -1,0 +1,74 @@
+package generate
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_generateAppScaffoldEnvironmentFiles(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Environment string
+		Error       error
+	}{
+		{
+			Name:        "app",
+			Environment: "development",
+		},
+		{
+			Name:        "metaphor",
+			Environment: "production",
+		},
+		{
+			Name:        "some-app",
+			Environment: "some-environment",
+		},
+	}
+
+	for _, test := range tests {
+		goldenDir := filepath.Join(".", "testdata", "scaffold", test.Environment)
+
+		fileData, err := generateAppScaffoldEnvironmentFiles(test.Name, test.Environment)
+		require.Equal(t, test.Error, err)
+
+		expectedFiles := []string{}
+		for k := range fileData.data {
+			expectedFiles = append(expectedFiles, k)
+		}
+
+		actualFiles := make([]string, 0)
+		err = filepath.WalkDir(goldenDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if d.IsDir() {
+				return nil
+			}
+
+			f, _ := strings.CutPrefix(path, goldenDir+string(filepath.Separator))
+			actualFiles = append(actualFiles, f)
+
+			actualFileContent, err := os.ReadFile(path)
+			require.Nil(t, err)
+
+			expectedFileContent, ok := fileData.data[f]
+			require.True(t, ok)
+
+			require.Equal(t, expectedFileContent.String(), string(actualFileContent))
+
+			return nil
+		})
+		require.Nil(t, err)
+
+		slices.Sort(expectedFiles)
+		slices.Sort(actualFiles)
+		require.Equal(t, expectedFiles, actualFiles)
+	}
+}

--- a/internal/generate/testdata/scaffold/development/app.yaml
+++ b/internal/generate/testdata/scaffold/development/app.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "development-environment-app"
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '45'
+spec:
+  project: default
+  source:
+    repoURL: <GITOPS_REPO_URL>
+    path: "registry/environments/development/app"
+    targetRevision: HEAD
+  destination:
+    name: in-cluster
+    namespace: "development"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/internal/generate/testdata/scaffold/development/app/Chart.yaml
+++ b/internal/generate/testdata/scaffold/development/app/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+description: "app example application"
+name: "app"
+type: application
+version: 1.0.0
+dependencies:
+  - name: "app"
+    repository: http://chartmuseum.chartmuseum.svc.cluster.local:8080
+    version: 0.0.1-rc.awaiting-ci

--- a/internal/generate/testdata/scaffold/development/app/values.yaml
+++ b/internal/generate/testdata/scaffold/development/app/values.yaml
@@ -1,0 +1,29 @@
+# This is a generated file. These values may not correspond to your own chart's values
+
+"app":
+  annotations: |
+    linkerd.io/inject: "enabled"
+  labels: |
+    mirror.linkerd.io/exported: "true"
+  image:
+    repository: "<CONTAINER_REGISTRY_URL>/app"
+  imagePullSecrets:
+    - name: docker-config
+  ingress:
+    className: nginx
+    enabled: true
+    annotations:
+      <CERT_MANAGER_ISSUER_ANNOTATION_1>
+      <CERT_MANAGER_ISSUER_ANNOTATION_2>
+      <CERT_MANAGER_ISSUER_ANNOTATION_3>
+      <CERT_MANAGER_ISSUER_ANNOTATION_4>
+      nginx.ingress.kubernetes.io/service-upstream: "true"
+    hosts:
+      - host: "app-development.<DOMAIN_NAME>"
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: "app-tls"
+        hosts:
+          - "app-development.<DOMAIN_NAME>"

--- a/internal/generate/testdata/scaffold/production/metaphor.yaml
+++ b/internal/generate/testdata/scaffold/production/metaphor.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "production-environment-metaphor"
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '45'
+spec:
+  project: default
+  source:
+    repoURL: <GITOPS_REPO_URL>
+    path: "registry/environments/production/metaphor"
+    targetRevision: HEAD
+  destination:
+    name: in-cluster
+    namespace: "production"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/internal/generate/testdata/scaffold/production/metaphor/Chart.yaml
+++ b/internal/generate/testdata/scaffold/production/metaphor/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+description: "metaphor example application"
+name: "metaphor"
+type: application
+version: 1.0.0
+dependencies:
+  - name: "metaphor"
+    repository: http://chartmuseum.chartmuseum.svc.cluster.local:8080
+    version: 0.0.1-rc.awaiting-ci

--- a/internal/generate/testdata/scaffold/production/metaphor/values.yaml
+++ b/internal/generate/testdata/scaffold/production/metaphor/values.yaml
@@ -1,0 +1,29 @@
+# This is a generated file. These values may not correspond to your own chart's values
+
+"metaphor":
+  annotations: |
+    linkerd.io/inject: "enabled"
+  labels: |
+    mirror.linkerd.io/exported: "true"
+  image:
+    repository: "<CONTAINER_REGISTRY_URL>/metaphor"
+  imagePullSecrets:
+    - name: docker-config
+  ingress:
+    className: nginx
+    enabled: true
+    annotations:
+      <CERT_MANAGER_ISSUER_ANNOTATION_1>
+      <CERT_MANAGER_ISSUER_ANNOTATION_2>
+      <CERT_MANAGER_ISSUER_ANNOTATION_3>
+      <CERT_MANAGER_ISSUER_ANNOTATION_4>
+      nginx.ingress.kubernetes.io/service-upstream: "true"
+    hosts:
+      - host: "metaphor-production.<DOMAIN_NAME>"
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: "metaphor-tls"
+        hosts:
+          - "metaphor-production.<DOMAIN_NAME>"

--- a/internal/generate/testdata/scaffold/some-environment/some-app.yaml
+++ b/internal/generate/testdata/scaffold/some-environment/some-app.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "some-environment-environment-some-app"
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '45'
+spec:
+  project: default
+  source:
+    repoURL: <GITOPS_REPO_URL>
+    path: "registry/environments/some-environment/some-app"
+    targetRevision: HEAD
+  destination:
+    name: in-cluster
+    namespace: "some-environment"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/internal/generate/testdata/scaffold/some-environment/some-app/Chart.yaml
+++ b/internal/generate/testdata/scaffold/some-environment/some-app/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+description: "some-app example application"
+name: "some-app"
+type: application
+version: 1.0.0
+dependencies:
+  - name: "some-app"
+    repository: http://chartmuseum.chartmuseum.svc.cluster.local:8080
+    version: 0.0.1-rc.awaiting-ci

--- a/internal/generate/testdata/scaffold/some-environment/some-app/values.yaml
+++ b/internal/generate/testdata/scaffold/some-environment/some-app/values.yaml
@@ -1,0 +1,29 @@
+# This is a generated file. These values may not correspond to your own chart's values
+
+"some-app":
+  annotations: |
+    linkerd.io/inject: "enabled"
+  labels: |
+    mirror.linkerd.io/exported: "true"
+  image:
+    repository: "<CONTAINER_REGISTRY_URL>/some-app"
+  imagePullSecrets:
+    - name: docker-config
+  ingress:
+    className: nginx
+    enabled: true
+    annotations:
+      <CERT_MANAGER_ISSUER_ANNOTATION_1>
+      <CERT_MANAGER_ISSUER_ANNOTATION_2>
+      <CERT_MANAGER_ISSUER_ANNOTATION_3>
+      <CERT_MANAGER_ISSUER_ANNOTATION_4>
+      nginx.ingress.kubernetes.io/service-upstream: "true"
+    hosts:
+      - host: "some-app-some-environment.<DOMAIN_NAME>"
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: "some-app-tls"
+        hosts:
+          - "some-app-some-environment.<DOMAIN_NAME>"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds the `generate app-scaffold` command. Tried to make this as generic as possible because the users are unlikely to have a `values.yaml` file that matches Metaphor

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes https://github.com/konstructio/kubefirst-api/issues/488

## How to test
<!-- Provide steps to test this PR -->
Run the app:
```bash
go run . generate app-scaffold # will prompt for name
go run . generate app-scaffold -n app # will generate in ./registry
go run . generate app-scaffold -n app --output-path /tmp/my-app # will generate in /tmp/my-app
go run . generate app-scaffold -n app --environment hello,world # will only generate environments "hello" and "world"
```