### PR TITLE
fix: kubeconfigfile creation

### DIFF
--- a/internal/launch/cmd.go
+++ b/internal/launch/cmd.go
@@ -216,6 +216,21 @@ Kubefirst console has already been deployed. To start over, run` + "`" + `kubefi
 
 	progress.CompleteStep("Create k3d cluster")
 
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		_, _, err := shell.ExecShellReturnStrings(
+			k3dClient,
+			"kubeconfig",
+			"get",
+			consoleClusterName,
+			"--output",
+			kubeconfigPath,
+		)
+		if err != nil {
+			progress.Error(fmt.Sprintf("error getting kubeconfig: %s", err))
+			return
+		}
+	}
+
 	// Establish Kubernetes client for console cluster
 	kcfg, err := k8s.CreateKubeConfig(false, kubeconfigPath)
 	if err != nil {


### PR DESCRIPTION
## Description  
Running the `kubefirst reset` command wipes the `./k1` directory, removing the kubeconfig file but leaving the k3d cluster intact.  
This functionality ensures that the kubeconfig file is recreated if it is missing, providing seamless operation even after a reset.

## How to Test  
1. Run the `kubefirst reset` command to clear the `./k1` directory.  
2. Use the CLI to provision a management cluster.  
3. Verify that the kubeconfig file is recreated and the cluster can be accessed without errors.
