### PR TITLE
refactor: create services for each cloud KRA-72

### DIFF
--- a/cmd/akamai/command.go
+++ b/cmd/akamai/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/konstructio/kubefirst-api/pkg/constants"
 	"github.com/konstructio/kubefirst/internal/common"
 	"github.com/konstructio/kubefirst/internal/progress"
+	"github.com/konstructio/kubefirst/internal/utilities"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +50,23 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the kubefirst platform running on akamai kubernetes",
 		TraverseChildren: true,
-		RunE:             createAkamai,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliFlags, err := utilities.GetFlags(cmd, "akamai")
+			if err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("failed to get flags: %w", err)
+			}
+
+			akamaiService := AkamaiService{
+				cliFlags: &cliFlags,
+			}
+
+			if err := akamaiService.CreateCluster(cmd.Context()); err != nil {
+				return fmt.Errorf("failed to create cluster: %w", err)
+			}
+
+			return nil
+		},
 	}
 
 	akamaiDefaults := constants.GetCloudDefaults().Akamai

--- a/cmd/akamai/command.go
+++ b/cmd/akamai/command.go
@@ -50,7 +50,7 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the kubefirst platform running on akamai kubernetes",
 		TraverseChildren: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliFlags, err := utilities.GetFlags(cmd, "akamai")
 			if err != nil {
 				progress.Error(err.Error())

--- a/cmd/akamai/command.go
+++ b/cmd/akamai/command.go
@@ -57,7 +57,7 @@ func Create() *cobra.Command {
 				return fmt.Errorf("failed to get flags: %w", err)
 			}
 
-			akamaiService := AkamaiService{
+			akamaiService := Service{
 				cliFlags: &cliFlags,
 			}
 

--- a/cmd/akamai/create.go
+++ b/cmd/akamai/create.go
@@ -23,11 +23,10 @@ type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *Service) CreateCluster(_ context.Context) error {
-
+func (s *Service) CreateCluster(ctx context.Context) error {
 	progress.DisplayLogHints(25)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
 	if !isValid {
 		return fmt.Errorf("catalog validation failed: %w", err)
 	}

--- a/cmd/akamai/create.go
+++ b/cmd/akamai/create.go
@@ -19,11 +19,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type AkamaiService struct {
+type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *AkamaiService) CreateCluster(_ context.Context) error {
+func (s *Service) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(25)
 

--- a/cmd/akamai/create.go
+++ b/cmd/akamai/create.go
@@ -7,6 +7,7 @@ See the LICENSE file for more details.
 package akamai
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -14,32 +15,30 @@ import (
 	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
 	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/utilities"
+	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 )
 
-func createAkamai(cmd *cobra.Command, _ []string) error {
-	cliFlags, err := utilities.GetFlags(cmd, "akamai")
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("failed to get flags: %w", err)
-	}
+type AkamaiService struct {
+	cliFlags *types.CliFlags
+}
+
+func (s *AkamaiService) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(25)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
 	if !isValid {
 		return fmt.Errorf("catalog validation failed: %w", err)
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider, cliFlags.DNSProvider)
+	err = ValidateProvidedFlags(s.cliFlags.GitProvider, s.cliFlags.DNSProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("failed to validate flags: %w", err)
 	}
 
-	if err := provision.ManagementCluster(cliFlags, catalogApps); err != nil {
+	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
 		return fmt.Errorf("failed to provision management cluster: %w", err)
 	}
 

--- a/cmd/aws/command.go
+++ b/cmd/aws/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/konstructio/kubefirst-api/pkg/constants"
 	"github.com/konstructio/kubefirst/internal/common"
 	"github.com/konstructio/kubefirst/internal/progress"
+	"github.com/konstructio/kubefirst/internal/utilities"
 	"github.com/spf13/cobra"
 )
 
@@ -79,7 +80,23 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the kubefirst platform running in aws",
 		TraverseChildren: true,
-		RunE:             createAws,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliFlags, err := utilities.GetFlags(cmd, "aws")
+			if err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("failed to get flags: %w", err)
+			}
+
+			awsService := AwsService{
+				cliFlags: &cliFlags,
+			}
+
+			if err := awsService.CreateCluster(cmd.Context()); err != nil {
+				return fmt.Errorf("failed to create cluster: %w", err)
+			}
+
+			return nil
+		},
 		// PreRun:           common.CheckDocker,
 	}
 

--- a/cmd/aws/command.go
+++ b/cmd/aws/command.go
@@ -80,7 +80,7 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the kubefirst platform running in aws",
 		TraverseChildren: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliFlags, err := utilities.GetFlags(cmd, "aws")
 			if err != nil {
 				progress.Error(err.Error())

--- a/cmd/aws/command.go
+++ b/cmd/aws/command.go
@@ -87,7 +87,7 @@ func Create() *cobra.Command {
 				return fmt.Errorf("failed to get flags: %w", err)
 			}
 
-			awsService := AwsService{
+			awsService := Service{
 				cliFlags: &cliFlags,
 			}
 

--- a/cmd/aws/create.go
+++ b/cmd/aws/create.go
@@ -26,11 +26,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-type AwsService struct {
+type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *AwsService) CreateCluster(ctx context.Context) error {
+func (s *Service) CreateCluster(ctx context.Context) error {
 
 	progress.DisplayLogHints(40)
 

--- a/cmd/aws/create.go
+++ b/cmd/aws/create.go
@@ -31,10 +31,9 @@ type Service struct {
 }
 
 func (s *Service) CreateCluster(ctx context.Context) error {
-
 	progress.DisplayLogHints(40)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
 	if !isValid {
 		return fmt.Errorf("invalid catalog apps: %w", err)
 	}

--- a/cmd/azure/command.go
+++ b/cmd/azure/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/konstructio/kubefirst-api/pkg/constants"
 	"github.com/konstructio/kubefirst/internal/common"
 	"github.com/konstructio/kubefirst/internal/progress"
+	"github.com/konstructio/kubefirst/internal/utilities"
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +55,23 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the kubefirst platform running on Azure kubernetes",
 		TraverseChildren: true,
-		RunE:             createAzure,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliFlags, err := utilities.GetFlags(cmd, "azure")
+			if err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("failed to get flags: %w", err)
+			}
+
+			azureService := AzureService{
+				cliFlags: &cliFlags,
+			}
+
+			if err := azureService.CreateCluster(cmd.Context()); err != nil {
+				return fmt.Errorf("failed to create Azure management cluster: %w", err)
+			}
+
+			return nil
+		},
 	}
 
 	azureDefaults := constants.GetCloudDefaults().Azure

--- a/cmd/azure/command.go
+++ b/cmd/azure/command.go
@@ -55,7 +55,7 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the kubefirst platform running on Azure kubernetes",
 		TraverseChildren: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliFlags, err := utilities.GetFlags(cmd, "azure")
 			if err != nil {
 				progress.Error(err.Error())

--- a/cmd/azure/command.go
+++ b/cmd/azure/command.go
@@ -62,7 +62,7 @@ func Create() *cobra.Command {
 				return fmt.Errorf("failed to get flags: %w", err)
 			}
 
-			azureService := AzureService{
+			azureService := Service{
 				cliFlags: &cliFlags,
 			}
 

--- a/cmd/azure/create.go
+++ b/cmd/azure/create.go
@@ -7,6 +7,7 @@ See the LICENSE file for more details.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -14,9 +15,8 @@ import (
 	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
 	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/utilities"
+	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 )
 
 // Environment variables required for authentication. This should be a
@@ -30,28 +30,27 @@ var envvarSecrets = []string{
 	"ARM_SUBSCRIPTION_ID",
 }
 
-func createAzure(cmd *cobra.Command, _ []string) error {
-	cliFlags, err := utilities.GetFlags(cmd, "azure")
-	if err != nil {
-		progress.Error(err.Error())
-		return nil
-	}
+type AzureService struct {
+	cliFlags *types.CliFlags
+}
+
+func (s *AzureService) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(20)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
 	if !isValid {
 		progress.Error(err.Error())
 		return nil
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider)
+	err = ValidateProvidedFlags(s.cliFlags.GitProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return nil
 	}
 
-	if err := provision.ManagementCluster(cliFlags, catalogApps); err != nil {
+	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
 		return fmt.Errorf("failed to provision management cluster: %w", err)
 	}
 

--- a/cmd/azure/create.go
+++ b/cmd/azure/create.go
@@ -34,11 +34,10 @@ type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *Service) CreateCluster(_ context.Context) error {
-
+func (s *Service) CreateCluster(ctx context.Context) error {
 	progress.DisplayLogHints(20)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
 	if !isValid {
 		progress.Error(err.Error())
 		return nil

--- a/cmd/azure/create.go
+++ b/cmd/azure/create.go
@@ -30,11 +30,11 @@ var envvarSecrets = []string{
 	"ARM_SUBSCRIPTION_ID",
 }
 
-type AzureService struct {
+type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *AzureService) CreateCluster(_ context.Context) error {
+func (s *Service) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(20)
 

--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/konstructio/kubefirst-api/pkg/constants"
 	"github.com/konstructio/kubefirst/internal/common"
 	"github.com/konstructio/kubefirst/internal/progress"
+	"github.com/konstructio/kubefirst/internal/utilities"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +61,26 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "Create the Kubefirst platform running on Civo Kubernetes",
 		TraverseChildren: true,
-		RunE:             createCivo,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			cliFlags, err := utilities.GetFlags(cmd, "civo")
+			if err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("failed to get CLI flags: %w", err)
+			}
+
+			service := &CivoService{
+				cliFlags: &cliFlags,
+			}
+
+			err = service.CreateCluster()
+
+			if err != nil {
+				return fmt.Errorf("failed to create Civo management cluster: %w", err)
+			}
+
+			return nil
+		},
 		// PreRun:           common.CheckDocker,
 	}
 

--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -69,7 +69,7 @@ func Create() *cobra.Command {
 				return fmt.Errorf("failed to get CLI flags: %w", err)
 			}
 
-			service := &CivoService{
+			service := &Service{
 				cliFlags: &cliFlags,
 			}
 

--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -62,7 +62,6 @@ func Create() *cobra.Command {
 		Short:            "Create the Kubefirst platform running on Civo Kubernetes",
 		TraverseChildren: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-
 			cliFlags, err := utilities.GetFlags(cmd, "civo")
 			if err != nil {
 				progress.Error(err.Error())

--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -73,7 +73,6 @@ func Create() *cobra.Command {
 			}
 
 			err = service.CreateCluster(cmd.Context())
-
 			if err != nil {
 				return fmt.Errorf("failed to create Civo management cluster: %w", err)
 			}

--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -73,7 +73,7 @@ func Create() *cobra.Command {
 				cliFlags: &cliFlags,
 			}
 
-			err = service.CreateCluster()
+			err = service.CreateCluster(cmd.Context())
 
 			if err != nil {
 				return fmt.Errorf("failed to create Civo management cluster: %w", err)

--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -61,7 +61,7 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "Create the Kubefirst platform running on Civo Kubernetes",
 		TraverseChildren: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 
 			cliFlags, err := utilities.GetFlags(cmd, "civo")
 			if err != nil {

--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -7,6 +7,7 @@ See the LICENSE file for more details.
 package civo
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -22,7 +23,7 @@ type CivoService struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *CivoService) CreateCluster() error {
+func (s *CivoService) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(15)
 

--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -23,11 +23,10 @@ type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *Service) CreateCluster(_ context.Context) error {
-
+func (s *Service) CreateCluster(ctx context.Context) error {
 	progress.DisplayLogHints(15)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
 	if !isValid {
 		return fmt.Errorf("catalog apps validation failed: %w", err)
 	}

--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -19,11 +19,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type CivoService struct {
+type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *CivoService) CreateCluster(_ context.Context) error {
+func (s *Service) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(15)
 

--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -14,32 +14,30 @@ import (
 	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
 	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/utilities"
+	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 )
 
-func createCivo(cmd *cobra.Command, _ []string) error {
-	cliFlags, err := utilities.GetFlags(cmd, "civo")
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("failed to get CLI flags: %w", err)
-	}
+type CivoService struct {
+	cliFlags *types.CliFlags
+}
+
+func (s *CivoService) CreateCluster() error {
 
 	progress.DisplayLogHints(15)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
 	if !isValid {
 		return fmt.Errorf("catalog apps validation failed: %w", err)
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider, cliFlags.DNSProvider)
+	err = ValidateProvidedFlags(s.cliFlags.GitProvider, s.cliFlags.DNSProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("failed to validate provided flags: %w", err)
 	}
 
-	if err := provision.ManagementCluster(cliFlags, catalogApps); err != nil {
+	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
 		return fmt.Errorf("failed to provision management cluster: %w", err)
 	}
 

--- a/cmd/digitalocean/command.go
+++ b/cmd/digitalocean/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/konstructio/kubefirst-api/pkg/constants"
 	"github.com/konstructio/kubefirst/internal/common"
 	"github.com/konstructio/kubefirst/internal/progress"
+	"github.com/konstructio/kubefirst/internal/utilities"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +53,23 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the Kubefirst platform running on DigitalOcean Kubernetes",
 		TraverseChildren: true,
-		RunE:             createDigitalocean,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliFlags, err := utilities.GetFlags(cmd, "digitalocean")
+			if err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("failed to get flags: %w", err)
+			}
+
+			digitaloceanService := DigitalOceanService{
+				cliFlags: &cliFlags,
+			}
+
+			if err := digitaloceanService.CreateCluster(cmd.Context()); err != nil {
+				return fmt.Errorf("failed to create DigitalOcean management cluster: %w", err)
+			}
+
+			return nil
+		},
 		// PreRun:           common.CheckDocker,
 	}
 

--- a/cmd/digitalocean/command.go
+++ b/cmd/digitalocean/command.go
@@ -53,7 +53,7 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the Kubefirst platform running on DigitalOcean Kubernetes",
 		TraverseChildren: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliFlags, err := utilities.GetFlags(cmd, "digitalocean")
 			if err != nil {
 				progress.Error(err.Error())

--- a/cmd/digitalocean/command.go
+++ b/cmd/digitalocean/command.go
@@ -60,7 +60,7 @@ func Create() *cobra.Command {
 				return fmt.Errorf("failed to get flags: %w", err)
 			}
 
-			digitaloceanService := DigitalOceanService{
+			digitaloceanService := Service{
 				cliFlags: &cliFlags,
 			}
 

--- a/cmd/digitalocean/create.go
+++ b/cmd/digitalocean/create.go
@@ -20,11 +20,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type DigitalOceanService struct {
+type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *DigitalOceanService) CreateCluster(_ context.Context) error {
+func (s *Service) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(20)
 

--- a/cmd/digitalocean/create.go
+++ b/cmd/digitalocean/create.go
@@ -7,6 +7,7 @@ See the LICENSE file for more details.
 package digitalocean
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -15,21 +16,19 @@ import (
 	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
 	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/utilities"
+	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 )
 
-func createDigitalocean(cmd *cobra.Command, _ []string) error {
-	cliFlags, err := utilities.GetFlags(cmd, "digitalocean")
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("failed to get CLI flags: %w", err)
-	}
+type DigitalOceanService struct {
+	cliFlags *types.CliFlags
+}
+
+func (s *DigitalOceanService) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(20)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
 	if err != nil {
 		return fmt.Errorf("catalog validation error: %w", err)
 	}
@@ -38,13 +37,13 @@ func createDigitalocean(cmd *cobra.Command, _ []string) error {
 		return errors.New("catalog did not pass a validation check")
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider, cliFlags.DNSProvider)
+	err = ValidateProvidedFlags(s.cliFlags.GitProvider, s.cliFlags.DNSProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("failed to validate provided flags: %w", err)
 	}
 
-	if err := provision.ManagementCluster(cliFlags, catalogApps); err != nil {
+	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
 		return fmt.Errorf("failed to provision management cluster: %w", err)
 	}
 

--- a/cmd/digitalocean/create.go
+++ b/cmd/digitalocean/create.go
@@ -24,11 +24,10 @@ type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *Service) CreateCluster(_ context.Context) error {
-
+func (s *Service) CreateCluster(ctx context.Context) error {
 	progress.DisplayLogHints(20)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
 	if err != nil {
 		return fmt.Errorf("catalog validation error: %w", err)
 	}

--- a/cmd/google/command.go
+++ b/cmd/google/command.go
@@ -61,7 +61,7 @@ func Create() *cobra.Command {
 				return fmt.Errorf("failed to get flags: %w", err)
 			}
 
-			googleService := GoogleService{
+			googleService := Service{
 				cliFlags: &cliFlags,
 			}
 

--- a/cmd/google/command.go
+++ b/cmd/google/command.go
@@ -54,7 +54,7 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the kubefirst platform running on GCP Kubernetes",
 		TraverseChildren: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliFlags, err := utilities.GetFlags(cmd, "google")
 			if err != nil {
 				progress.Error(err.Error())

--- a/cmd/google/command.go
+++ b/cmd/google/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/konstructio/kubefirst-api/pkg/constants"
 	"github.com/konstructio/kubefirst/internal/common"
 	"github.com/konstructio/kubefirst/internal/progress"
+	"github.com/konstructio/kubefirst/internal/utilities"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +54,25 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the kubefirst platform running on GCP Kubernetes",
 		TraverseChildren: true,
-		RunE:             createGoogle,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliFlags, err := utilities.GetFlags(cmd, "google")
+			if err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("failed to get flags: %w", err)
+			}
+
+			googleService := GoogleService{
+				cliFlags: &cliFlags,
+			}
+
+			err = googleService.CreateCluster(cmd.Context())
+			if err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("failed to create google management cluster: %w", err)
+			}
+
+			return nil
+		},
 		// PreRun:           common.CheckDocker,
 	}
 

--- a/cmd/google/create.go
+++ b/cmd/google/create.go
@@ -24,11 +24,10 @@ type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *Service) CreateCluster(_ context.Context) error {
-
+func (s *Service) CreateCluster(ctx context.Context) error {
 	progress.DisplayLogHints(20)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
 	if !isValid {
 		return fmt.Errorf("catalog apps validation failed: %w", err)
 	}

--- a/cmd/google/create.go
+++ b/cmd/google/create.go
@@ -20,11 +20,11 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // required for authentication
 )
 
-type GoogleService struct {
+type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *GoogleService) CreateCluster(_ context.Context) error {
+func (s *Service) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(20)
 

--- a/cmd/google/create.go
+++ b/cmd/google/create.go
@@ -7,6 +7,7 @@ See the LICENSE file for more details.
 package google
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -14,33 +15,31 @@ import (
 	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
 	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/utilities"
+	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // required for authentication
 )
 
-func createGoogle(cmd *cobra.Command, _ []string) error {
-	cliFlags, err := utilities.GetFlags(cmd, "google")
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("failed to get flags: %w", err)
-	}
+type GoogleService struct {
+	cliFlags *types.CliFlags
+}
+
+func (s *GoogleService) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(20)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
 	if !isValid {
 		return fmt.Errorf("catalog apps validation failed: %w", err)
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider)
+	err = ValidateProvidedFlags(s.cliFlags.GitProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("validation of provided flags failed: %w", err)
 	}
 
-	if err := provision.ManagementCluster(cliFlags, catalogApps); err != nil {
+	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
 		return fmt.Errorf("failed to provision management cluster: %w", err)
 	}
 

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -73,7 +73,7 @@ func runK3d(cmd *cobra.Command, _ []string) error {
 	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
 	utils.DisplayLogHints()
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(cmd.Context(), cliFlags.InstallCatalogApps)
 	if err != nil {
 		return fmt.Errorf("failed to validate catalog apps: %w", err)
 	}

--- a/cmd/k3s/command.go
+++ b/cmd/k3s/command.go
@@ -50,7 +50,7 @@ func Create() *cobra.Command {
 				return fmt.Errorf("failed to get flags: %w", err)
 			}
 
-			k3sService := K3sService{
+			k3sService := Service{
 				cliFlags: &cliFlags,
 			}
 

--- a/cmd/k3s/command.go
+++ b/cmd/k3s/command.go
@@ -59,7 +59,6 @@ func Create() *cobra.Command {
 			}
 
 			return nil
-
 		},
 		// PreRun:           common.CheckDocker,
 	}

--- a/cmd/k3s/command.go
+++ b/cmd/k3s/command.go
@@ -44,7 +44,7 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the kubefirst platform running on premise",
 		TraverseChildren: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliFlags, err := utilities.GetFlags(cmd, "k3s")
 			if err != nil {
 				return fmt.Errorf("failed to get flags: %w", err)

--- a/cmd/k3s/command.go
+++ b/cmd/k3s/command.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/konstructio/kubefirst/internal/common"
+	"github.com/konstructio/kubefirst/internal/utilities"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +44,23 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "create the kubefirst platform running on premise",
 		TraverseChildren: true,
-		RunE:             createK3s,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliFlags, err := utilities.GetFlags(cmd, "k3s")
+			if err != nil {
+				return fmt.Errorf("failed to get flags: %w", err)
+			}
+
+			k3sService := K3sService{
+				cliFlags: &cliFlags,
+			}
+
+			if err := k3sService.CreateCluster(cmd.Context()); err != nil {
+				return fmt.Errorf("failed to create k3s management cluster: %w", err)
+			}
+
+			return nil
+
+		},
 		// PreRun:           common.CheckDocker,
 	}
 

--- a/cmd/k3s/create.go
+++ b/cmd/k3s/create.go
@@ -25,11 +25,10 @@ type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *Service) CreateCluster(_ context.Context) error {
-
+func (s *Service) CreateCluster(ctx context.Context) error {
 	progress.DisplayLogHints(20)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
 	if err != nil {
 		return fmt.Errorf("validation of catalog apps failed: %w", err)
 	}

--- a/cmd/k3s/create.go
+++ b/cmd/k3s/create.go
@@ -7,6 +7,7 @@ See the LICENSE file for more details.
 package k3s
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -16,21 +17,19 @@ import (
 	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
 	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/utilities"
-	"github.com/spf13/cobra"
+	"github.com/konstructio/kubefirst/internal/types"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // required for k8s authentication
 )
 
-func createK3s(cmd *cobra.Command, _ []string) error {
-	cliFlags, err := utilities.GetFlags(cmd, "k3s")
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("error collecting flags: %w", err)
-	}
+type K3sService struct {
+	cliFlags *types.CliFlags
+}
+
+func (s *K3sService) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(20)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
 	if err != nil {
 		return fmt.Errorf("validation of catalog apps failed: %w", err)
 	}
@@ -39,13 +38,13 @@ func createK3s(cmd *cobra.Command, _ []string) error {
 		return errors.New("catalog validation failed")
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider)
+	err = ValidateProvidedFlags(s.cliFlags.GitProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("provided flags validation failed: %w", err)
 	}
 
-	if err := provision.ManagementCluster(cliFlags, catalogApps); err != nil {
+	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
 		return fmt.Errorf("failed to provision management cluster: %w", err)
 	}
 

--- a/cmd/k3s/create.go
+++ b/cmd/k3s/create.go
@@ -21,11 +21,11 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // required for k8s authentication
 )
 
-type K3sService struct {
+type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *K3sService) CreateCluster(_ context.Context) error {
+func (s *Service) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(20)
 

--- a/cmd/vultr/command.go
+++ b/cmd/vultr/command.go
@@ -60,7 +60,7 @@ func Create() *cobra.Command {
 				return fmt.Errorf("failed to get flags: %w", err)
 			}
 
-			vultrService := VultrService{
+			vultrService := Service{
 				cliFlags: &cliFlags,
 			}
 

--- a/cmd/vultr/command.go
+++ b/cmd/vultr/command.go
@@ -53,7 +53,7 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "Create the Kubefirst platform running on Vultr Kubernetes",
 		TraverseChildren: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cliFlags, err := utilities.GetFlags(cmd, "vultr")
 			if err != nil {
 				progress.Error(err.Error())

--- a/cmd/vultr/command.go
+++ b/cmd/vultr/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/konstructio/kubefirst-api/pkg/constants"
 	"github.com/konstructio/kubefirst/internal/common"
 	"github.com/konstructio/kubefirst/internal/progress"
+	"github.com/konstructio/kubefirst/internal/utilities"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +53,25 @@ func Create() *cobra.Command {
 		Use:              "create",
 		Short:            "Create the Kubefirst platform running on Vultr Kubernetes",
 		TraverseChildren: true,
-		RunE:             createVultr,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliFlags, err := utilities.GetFlags(cmd, "vultr")
+			if err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("failed to get flags: %w", err)
+			}
+
+			vultrService := VultrService{
+				cliFlags: &cliFlags,
+			}
+
+			err = vultrService.CreateCluster(cmd.Context())
+			if err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("failed to create vultr management cluster: %w", err)
+			}
+
+			return nil
+		},
 		// PreRun:           common.CheckDocker,
 	}
 

--- a/cmd/vultr/create.go
+++ b/cmd/vultr/create.go
@@ -20,11 +20,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type VultrService struct {
+type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *VultrService) CreateCluster(_ context.Context) error {
+func (s *Service) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(15)
 

--- a/cmd/vultr/create.go
+++ b/cmd/vultr/create.go
@@ -7,6 +7,7 @@ See the LICENSE file for more details.
 package vultr
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -15,21 +16,19 @@ import (
 	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
 	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/utilities"
+	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 )
 
-func createVultr(cmd *cobra.Command, _ []string) error {
-	cliFlags, err := utilities.GetFlags(cmd, "vultr")
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("failed to get flags: %w", err)
-	}
+type VultrService struct {
+	cliFlags *types.CliFlags
+}
+
+func (s *VultrService) CreateCluster(_ context.Context) error {
 
 	progress.DisplayLogHints(15)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
 	if err != nil {
 		return fmt.Errorf("catalog apps validation failed: %w", err)
 	}
@@ -38,13 +37,13 @@ func createVultr(cmd *cobra.Command, _ []string) error {
 		return errors.New("catalog validation failed")
 	}
 
-	err = ValidateProvidedFlags(cliFlags.GitProvider, cliFlags.DNSProvider)
+	err = ValidateProvidedFlags(s.cliFlags.GitProvider, s.cliFlags.DNSProvider)
 	if err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("invalid provided flags: %w", err)
 	}
 
-	if err := provision.ManagementCluster(cliFlags, catalogApps); err != nil {
+	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
 		return fmt.Errorf("failed to provision management cluster: %w", err)
 	}
 

--- a/cmd/vultr/create.go
+++ b/cmd/vultr/create.go
@@ -24,11 +24,10 @@ type Service struct {
 	cliFlags *types.CliFlags
 }
 
-func (s *Service) CreateCluster(_ context.Context) error {
-
+func (s *Service) CreateCluster(ctx context.Context) error {
 	progress.DisplayLogHints(15)
 
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(s.cliFlags.InstallCatalogApps)
+	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
 	if err != nil {
 		return fmt.Errorf("catalog apps validation failed: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/google/go-github/v52 v52.0.0
 	github.com/hashicorp/vault/api v1.15.0
+	github.com/konstructio/cli-utils v0.0.0-20250121163216-a915a9d11340
 	github.com/konstructio/kubefirst-api v0.122.0
 	github.com/kubefirst/metrics-client v0.3.0
 	github.com/minio/minio-go/v7 v7.0.81
@@ -37,10 +38,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190816222228-6d55c1b1f1ca+incompatible
 )
 
-require (
-	github.com/konstructio/cli-utils v0.0.0-20250121163216-a915a9d11340 // indirect
-	github.com/tj/go-spin v1.1.0 // indirect
-)
+require github.com/tj/go-spin v1.1.0 // indirect
 
 require (
 	cel.dev/expr v0.16.1 // indirect

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -46,7 +46,7 @@ func ReadActiveApplications(ctx context.Context) (apiTypes.GitopsCatalogApps, er
 		return apiTypes.GitopsCatalogApps{}, fmt.Errorf("error retrieving gitops catalog repository content: %w", err)
 	}
 
-	index, err := gh.ReadGitopsCatalogIndex(activeContent)
+	index, err := gh.ReadGitopsCatalogIndex(ctx, activeContent)
 	if err != nil {
 		return apiTypes.GitopsCatalogApps{}, fmt.Errorf("error retrieving gitops catalog index content: %w", err)
 	}
@@ -132,10 +132,10 @@ func (gh *GitHubClient) ReadGitopsCatalogRepoContents(ctx context.Context) ([]*g
 }
 
 // ReadGitopsCatalogIndex reads the gitops catalog repository index
-func (gh *GitHubClient) ReadGitopsCatalogIndex(contents []*git.RepositoryContent) ([]byte, error) {
+func (gh *GitHubClient) ReadGitopsCatalogIndex(ctx context.Context, contents []*git.RepositoryContent) ([]byte, error) {
 	for _, content := range contents {
 		if *content.Type == "file" && *content.Name == "index.yaml" {
-			b, err := gh.readFileContents(content)
+			b, err := gh.readFileContents(ctx, content)
 			if err != nil {
 				return nil, fmt.Errorf("error reading index.yaml file: %w", err)
 			}
@@ -147,9 +147,9 @@ func (gh *GitHubClient) ReadGitopsCatalogIndex(contents []*git.RepositoryContent
 }
 
 // readFileContents parses the contents of a file in a GitHub repository
-func (gh *GitHubClient) readFileContents(content *git.RepositoryContent) ([]byte, error) {
+func (gh *GitHubClient) readFileContents(ctx context.Context, content *git.RepositoryContent) ([]byte, error) {
 	rc, _, err := gh.Client.Repositories.DownloadContents(
-		context.Background(),
+		ctx,
 		KubefirstGitHubOrganization,
 		KubefirstGitopsCatalogRepository,
 		*content.Path,

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -36,12 +36,12 @@ func NewGitHub() *git.Client {
 	return git.NewClient(nil)
 }
 
-func ReadActiveApplications() (apiTypes.GitopsCatalogApps, error) {
+func ReadActiveApplications(ctx context.Context) (apiTypes.GitopsCatalogApps, error) {
 	gh := GitHubClient{
 		Client: NewGitHub(),
 	}
 
-	activeContent, err := gh.ReadGitopsCatalogRepoContents()
+	activeContent, err := gh.ReadGitopsCatalogRepoContents(ctx)
 	if err != nil {
 		return apiTypes.GitopsCatalogApps{}, fmt.Errorf("error retrieving gitops catalog repository content: %w", err)
 	}
@@ -61,7 +61,7 @@ func ReadActiveApplications() (apiTypes.GitopsCatalogApps, error) {
 	return out, nil
 }
 
-func ValidateCatalogApps(catalogApps string) (bool, []apiTypes.GitopsCatalogApp, error) {
+func ValidateCatalogApps(ctx context.Context, catalogApps string) (bool, []apiTypes.GitopsCatalogApp, error) {
 	items := strings.Split(catalogApps, ",")
 
 	gitopsCatalogapps := []apiTypes.GitopsCatalogApp{}
@@ -69,7 +69,7 @@ func ValidateCatalogApps(catalogApps string) (bool, []apiTypes.GitopsCatalogApp,
 		return true, gitopsCatalogapps, nil
 	}
 
-	apps, err := ReadActiveApplications()
+	apps, err := ReadActiveApplications(ctx)
 	if err != nil {
 		log.Error().Msgf("error getting gitops catalog applications: %s", err)
 		return false, gitopsCatalogapps, err
@@ -116,9 +116,9 @@ func ValidateCatalogApps(catalogApps string) (bool, []apiTypes.GitopsCatalogApp,
 	return true, gitopsCatalogapps, nil
 }
 
-func (gh *GitHubClient) ReadGitopsCatalogRepoContents() ([]*git.RepositoryContent, error) {
+func (gh *GitHubClient) ReadGitopsCatalogRepoContents(ctx context.Context) ([]*git.RepositoryContent, error) {
 	_, directoryContent, _, err := gh.Client.Repositories.GetContents(
-		context.Background(),
+		ctx,
 		KubefirstGitHubOrganization,
 		KubefirstGitopsCatalogRepository,
 		basePath,

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -56,7 +56,7 @@ func CreateMgmtClusterRequest(gitAuth apiTypes.GitAuth, cliFlags types.CliFlags,
 	return nil
 }
 
-func ManagementCluster(cliFlags types.CliFlags, catalogApps []apiTypes.GitopsCatalogApp) error {
+func ManagementCluster(cliFlags *types.CliFlags, catalogApps []apiTypes.GitopsCatalogApp) error {
 	clusterSetupComplete := viper.GetBool("kubefirst-checks.cluster-install-complete")
 	if clusterSetupComplete {
 		err := fmt.Errorf("this cluster install process has already completed successfully")
@@ -110,7 +110,7 @@ func ManagementCluster(cliFlags types.CliFlags, catalogApps []apiTypes.GitopsCat
 		return fmt.Errorf("API availability check failed: %w", err)
 	}
 
-	if err := CreateMgmtClusterRequest(gitAuth, cliFlags, catalogApps); err != nil {
+	if err := CreateMgmtClusterRequest(gitAuth, *cliFlags, catalogApps); err != nil {
 		progress.Error(err.Error())
 		return fmt.Errorf("failed to create management cluster: %w", err)
 	}


### PR DESCRIPTION
## Description
This moves the logic of creating the management cluster into a separate struct.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
Automated acceptance test - Commands to CLI are running the provisioning process
