### PR TITLE
refactor: remove cloud specific services KRA-72

### DIFF
--- a/cmd/akamai/create.go
+++ b/cmd/akamai/create.go
@@ -7,42 +7,13 @@ See the LICENSE file for more details.
 package akamai
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	internalssh "github.com/konstructio/kubefirst-api/pkg/ssh"
-	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
-	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
 )
-
-type Service struct {
-	cliFlags *types.CliFlags
-}
-
-func (s *Service) CreateCluster(ctx context.Context) error {
-	progress.DisplayLogHints(25)
-
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
-	if !isValid {
-		return fmt.Errorf("catalog validation failed: %w", err)
-	}
-
-	err = ValidateProvidedFlags(s.cliFlags.GitProvider, s.cliFlags.DNSProvider)
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("failed to validate flags: %w", err)
-	}
-
-	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
-		return fmt.Errorf("failed to provision management cluster: %w", err)
-	}
-
-	return nil
-}
 
 func ValidateProvidedFlags(gitProvider, dnsProvider string) error {
 	progress.AddStep("Validate provided flags")

--- a/cmd/azure/create.go
+++ b/cmd/azure/create.go
@@ -7,15 +7,11 @@ See the LICENSE file for more details.
 package azure
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	internalssh "github.com/konstructio/kubefirst-api/pkg/ssh"
-	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
-	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
 )
 
@@ -28,32 +24,6 @@ var envvarSecrets = []string{
 	"ARM_CLIENT_SECRET",
 	"ARM_TENANT_ID",
 	"ARM_SUBSCRIPTION_ID",
-}
-
-type Service struct {
-	cliFlags *types.CliFlags
-}
-
-func (s *Service) CreateCluster(ctx context.Context) error {
-	progress.DisplayLogHints(20)
-
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
-	if !isValid {
-		progress.Error(err.Error())
-		return nil
-	}
-
-	err = ValidateProvidedFlags(s.cliFlags.GitProvider)
-	if err != nil {
-		progress.Error(err.Error())
-		return nil
-	}
-
-	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
-		return fmt.Errorf("failed to provision management cluster: %w", err)
-	}
-
-	return nil
 }
 
 func ValidateProvidedFlags(gitProvider string) error {

--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -7,42 +7,13 @@ See the LICENSE file for more details.
 package civo
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	internalssh "github.com/konstructio/kubefirst-api/pkg/ssh"
-	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
-	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
 )
-
-type Service struct {
-	cliFlags *types.CliFlags
-}
-
-func (s *Service) CreateCluster(ctx context.Context) error {
-	progress.DisplayLogHints(15)
-
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
-	if !isValid {
-		return fmt.Errorf("catalog apps validation failed: %w", err)
-	}
-
-	err = ValidateProvidedFlags(s.cliFlags.GitProvider, s.cliFlags.DNSProvider)
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("failed to validate provided flags: %w", err)
-	}
-
-	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
-		return fmt.Errorf("failed to provision management cluster: %w", err)
-	}
-
-	return nil
-}
 
 func ValidateProvidedFlags(gitProvider, dnsProvider string) error {
 	progress.AddStep("Validate provided flags")

--- a/cmd/digitalocean/create.go
+++ b/cmd/digitalocean/create.go
@@ -7,47 +7,13 @@ See the LICENSE file for more details.
 package digitalocean
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"os"
 
 	internalssh "github.com/konstructio/kubefirst-api/pkg/ssh"
-	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
-	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
 )
-
-type Service struct {
-	cliFlags *types.CliFlags
-}
-
-func (s *Service) CreateCluster(ctx context.Context) error {
-	progress.DisplayLogHints(20)
-
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
-	if err != nil {
-		return fmt.Errorf("catalog validation error: %w", err)
-	}
-
-	if !isValid {
-		return errors.New("catalog did not pass a validation check")
-	}
-
-	err = ValidateProvidedFlags(s.cliFlags.GitProvider, s.cliFlags.DNSProvider)
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("failed to validate provided flags: %w", err)
-	}
-
-	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
-		return fmt.Errorf("failed to provision management cluster: %w", err)
-	}
-
-	return nil
-}
 
 func ValidateProvidedFlags(gitProvider, dnsProvider string) error {
 	progress.AddStep("Validate provided flags")

--- a/cmd/google/create.go
+++ b/cmd/google/create.go
@@ -7,43 +7,14 @@ See the LICENSE file for more details.
 package google
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	internalssh "github.com/konstructio/kubefirst-api/pkg/ssh"
-	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
-	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // required for authentication
 )
-
-type Service struct {
-	cliFlags *types.CliFlags
-}
-
-func (s *Service) CreateCluster(ctx context.Context) error {
-	progress.DisplayLogHints(20)
-
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
-	if !isValid {
-		return fmt.Errorf("catalog apps validation failed: %w", err)
-	}
-
-	err = ValidateProvidedFlags(s.cliFlags.GitProvider)
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("validation of provided flags failed: %w", err)
-	}
-
-	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
-		return fmt.Errorf("failed to provision management cluster: %w", err)
-	}
-
-	return nil
-}
 
 func ValidateProvidedFlags(gitProvider string) error {
 	progress.AddStep("Validate provided flags")

--- a/cmd/k3s/create.go
+++ b/cmd/k3s/create.go
@@ -7,48 +7,14 @@ See the LICENSE file for more details.
 package k3s
 
 import (
-	"context"
-	"errors"
 	"fmt"
 
 	"github.com/rs/zerolog/log"
 
 	internalssh "github.com/konstructio/kubefirst-api/pkg/ssh"
-	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
-	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/types"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // required for k8s authentication
 )
-
-type Service struct {
-	cliFlags *types.CliFlags
-}
-
-func (s *Service) CreateCluster(ctx context.Context) error {
-	progress.DisplayLogHints(20)
-
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
-	if err != nil {
-		return fmt.Errorf("validation of catalog apps failed: %w", err)
-	}
-
-	if !isValid {
-		return errors.New("catalog validation failed")
-	}
-
-	err = ValidateProvidedFlags(s.cliFlags.GitProvider)
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("provided flags validation failed: %w", err)
-	}
-
-	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
-		return fmt.Errorf("failed to provision management cluster: %w", err)
-	}
-
-	return nil
-}
 
 func ValidateProvidedFlags(gitProvider string) error {
 	progress.AddStep("Validate provided flags")

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -37,7 +37,6 @@ func launchUp() *cobra.Command {
 		Short:            "launch new console and api instance",
 		TraverseChildren: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-
 			if err := launch.Up(cmd.Context(), additionalHelmFlags, false, true); err != nil {
 				progress.Error(err.Error())
 				return fmt.Errorf("failed to launch console and api: %w", err)

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/konstructio/kubefirst/internal/launch"
+	"github.com/konstructio/kubefirst/internal/progress"
 	"github.com/spf13/cobra"
 )
 
@@ -35,8 +36,14 @@ func launchUp() *cobra.Command {
 		Use:              "up",
 		Short:            "launch new console and api instance",
 		TraverseChildren: true,
-		Run: func(_ *cobra.Command, _ []string) {
-			launch.Up(additionalHelmFlags, false, true)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+
+			if err := launch.Up(cmd.Context(), additionalHelmFlags, false, true); err != nil {
+				progress.Error(err.Error())
+				return fmt.Errorf("failed to launch console and api: %w", err)
+			}
+
+			return nil
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,8 @@ func Execute() {
 		SilenceUsage:  true,
 	}
 
+	output := rootCmd.ErrOrStderr()
+
 	rootCmd.AddCommand(
 		aws.NewCommand(),
 		azure.NewCommand(),
@@ -74,9 +76,8 @@ func Execute() {
 	common.CheckForVersionUpdate()
 	progressPrinter.GetInstance()
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println("Error occurred during command execution:", err)
-		fmt.Println("If a detailed error message was available, please make the necessary corrections before retrying.")
-		fmt.Println("You can re-run the last command to try the operation again.")
+		fmt.Fprintln(output, "If a detailed error message was available, please make the necessary corrections before retrying.")
+		fmt.Fprintln(output, "You can re-run the last command to try the operation again.")
 		progress.Progress.Quit()
 	}
 }

--- a/cmd/vultr/create.go
+++ b/cmd/vultr/create.go
@@ -7,47 +7,13 @@ See the LICENSE file for more details.
 package vultr
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"os"
 
 	internalssh "github.com/konstructio/kubefirst-api/pkg/ssh"
-	"github.com/konstructio/kubefirst/internal/catalog"
 	"github.com/konstructio/kubefirst/internal/progress"
-	"github.com/konstructio/kubefirst/internal/provision"
-	"github.com/konstructio/kubefirst/internal/types"
 	"github.com/rs/zerolog/log"
 )
-
-type Service struct {
-	cliFlags *types.CliFlags
-}
-
-func (s *Service) CreateCluster(ctx context.Context) error {
-	progress.DisplayLogHints(15)
-
-	isValid, catalogApps, err := catalog.ValidateCatalogApps(ctx, s.cliFlags.InstallCatalogApps)
-	if err != nil {
-		return fmt.Errorf("catalog apps validation failed: %w", err)
-	}
-
-	if !isValid {
-		return errors.New("catalog validation failed")
-	}
-
-	err = ValidateProvidedFlags(s.cliFlags.GitProvider, s.cliFlags.DNSProvider)
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("invalid provided flags: %w", err)
-	}
-
-	if err := provision.ManagementCluster(s.cliFlags, catalogApps); err != nil {
-		return fmt.Errorf("failed to provision management cluster: %w", err)
-	}
-
-	return nil
-}
 
 func ValidateProvidedFlags(gitProvider, dnsProvider string) error {
 	progress.AddStep("Validate provided flags")

--- a/internal/launch/cmd.go
+++ b/internal/launch/cmd.go
@@ -50,8 +50,7 @@ Kubefirst console has already been deployed. To start over, run` + "`" + `kubefi
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		err = fmt.Errorf("unable to get user's home directory: %s", err)
-		return err
+		return fmt.Errorf("error getting user's home directory: %w", err)
 	}
 
 	dir := fmt.Sprintf("%s/.k1/%s", homeDir, consoleClusterName)
@@ -460,7 +459,6 @@ Kubefirst console has already been deployed. To start over, run` + "`" + `kubefi
 		}, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("error creating kubernetes secret for cert: %w", err)
-
 		}
 		time.Sleep(5 * time.Second)
 		log.Info().Msg("Created Kubernetes Secret for certificate")

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -104,69 +104,10 @@ func (p *Provisioner) ProvisionManagementCluster(ctx context.Context, cliFlags *
 	isK1Debug := strings.ToLower(os.Getenv("K1_LOCAL_DEBUG")) == "true"
 
 	if !k3dClusterCreationComplete && !isK1Debug {
-		launch.Up(nil, true, cliFlags.UseTelemetry)
-	}
-
-	err = utils.IsAppAvailable(fmt.Sprintf("%s/api/proxyHealth", cluster.GetConsoleIngressURL()), "kubefirst api")
-	if err != nil {
-		progress.Error("unable to start kubefirst api")
-		return fmt.Errorf("API availability check failed: %w", err)
-	}
-
-	if err := CreateMgmtClusterRequest(gitAuth, *cliFlags, catalogApps); err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("failed to create management cluster: %w", err)
-	}
-
-	return nil
-}
-
-func ManagementCluster(cliFlags *types.CliFlags, catalogApps []apiTypes.GitopsCatalogApp) error {
-	clusterSetupComplete := viper.GetBool("kubefirst-checks.cluster-install-complete")
-	if clusterSetupComplete {
-		err := fmt.Errorf("this cluster install process has already completed successfully")
-		progress.Error(err.Error())
-		return nil
-	}
-
-	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
-
-	gitAuth, err := gitShim.ValidateGitCredentials(cliFlags.GitProvider, cliFlags.GithubOrg, cliFlags.GitlabGroup)
-	if err != nil {
-		progress.Error(err.Error())
-		return fmt.Errorf("failed to validate git credentials: %w", err)
-	}
-
-	// Validate git
-	executionControl := viper.GetBool(fmt.Sprintf("kubefirst-checks.%s-credentials", cliFlags.GitProvider))
-	if !executionControl {
-		newRepositoryNames := []string{"gitops", "metaphor"}
-		newTeamNames := []string{"admins", "developers"}
-
-		initGitParameters := gitShim.GitInitParameters{
-			GitProvider:  cliFlags.GitProvider,
-			GitToken:     gitAuth.Token,
-			GitOwner:     gitAuth.Owner,
-			Repositories: newRepositoryNames,
-			Teams:        newTeamNames,
-		}
-
-		err = gitShim.InitializeGitProvider(&initGitParameters)
-		if err != nil {
+		if err := launch.Up(ctx, nil, true, cliFlags.UseTelemetry); err != nil {
 			progress.Error(err.Error())
-			return fmt.Errorf("failed to initialize Git provider: %w", err)
+			return fmt.Errorf("failed to launch k3d cluster: %w", err)
 		}
-	}
-	viper.Set(fmt.Sprintf("kubefirst-checks.%s-credentials", cliFlags.GitProvider), true)
-	if err = viper.WriteConfig(); err != nil {
-		return fmt.Errorf("failed to write viper config: %w", err)
-	}
-
-	k3dClusterCreationComplete := viper.GetBool("launch.deployed")
-	isK1Debug := strings.ToLower(os.Getenv("K1_LOCAL_DEBUG")) == "true"
-
-	if !k3dClusterCreationComplete && !isK1Debug {
-		launch.Up(nil, true, cliFlags.UseTelemetry)
 	}
 
 	err = utils.IsAppAvailable(fmt.Sprintf("%s/api/proxyHealth", cluster.GetConsoleIngressURL()), "kubefirst api")

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -7,6 +7,7 @@ See the LICENSE file for more details.
 package provision
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -53,6 +54,70 @@ func CreateMgmtClusterRequest(gitAuth apiTypes.GitAuth, cliFlags types.CliFlags,
 	}
 
 	progress.StartProvisioning(clusterRecord.ClusterName)
+	return nil
+}
+
+type Provisioner struct{}
+
+func (p *Provisioner) ProvisionManagementCluster(ctx context.Context, cliFlags *types.CliFlags, catalogApps []apiTypes.GitopsCatalogApp) error {
+	clusterSetupComplete := viper.GetBool("kubefirst-checks.cluster-install-complete")
+	if clusterSetupComplete {
+		err := fmt.Errorf("this cluster install process has already completed successfully")
+		progress.Error(err.Error())
+		return nil
+	}
+
+	utilities.CreateK1ClusterDirectory(cliFlags.ClusterName)
+
+	gitAuth, err := gitShim.ValidateGitCredentials(cliFlags.GitProvider, cliFlags.GithubOrg, cliFlags.GitlabGroup)
+	if err != nil {
+		progress.Error(err.Error())
+		return fmt.Errorf("failed to validate git credentials: %w", err)
+	}
+
+	// Validate git
+	executionControl := viper.GetBool(fmt.Sprintf("kubefirst-checks.%s-credentials", cliFlags.GitProvider))
+	if !executionControl {
+		newRepositoryNames := []string{"gitops", "metaphor"}
+		newTeamNames := []string{"admins", "developers"}
+
+		initGitParameters := gitShim.GitInitParameters{
+			GitProvider:  cliFlags.GitProvider,
+			GitToken:     gitAuth.Token,
+			GitOwner:     gitAuth.Owner,
+			Repositories: newRepositoryNames,
+			Teams:        newTeamNames,
+		}
+
+		err = gitShim.InitializeGitProvider(&initGitParameters)
+		if err != nil {
+			progress.Error(err.Error())
+			return fmt.Errorf("failed to initialize Git provider: %w", err)
+		}
+	}
+	viper.Set(fmt.Sprintf("kubefirst-checks.%s-credentials", cliFlags.GitProvider), true)
+	if err = viper.WriteConfig(); err != nil {
+		return fmt.Errorf("failed to write viper config: %w", err)
+	}
+
+	k3dClusterCreationComplete := viper.GetBool("launch.deployed")
+	isK1Debug := strings.ToLower(os.Getenv("K1_LOCAL_DEBUG")) == "true"
+
+	if !k3dClusterCreationComplete && !isK1Debug {
+		launch.Up(nil, true, cliFlags.UseTelemetry)
+	}
+
+	err = utils.IsAppAvailable(fmt.Sprintf("%s/api/proxyHealth", cluster.GetConsoleIngressURL()), "kubefirst api")
+	if err != nil {
+		progress.Error("unable to start kubefirst api")
+		return fmt.Errorf("API availability check failed: %w", err)
+	}
+
+	if err := CreateMgmtClusterRequest(gitAuth, *cliFlags, catalogApps); err != nil {
+		progress.Error(err.Error())
+		return fmt.Errorf("failed to create management cluster: %w", err)
+	}
+
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -141,7 +141,6 @@ func main() {
 		}()
 
 		progress.Progress.Run()
-
 	} else {
 		cmd.Execute()
 	}

--- a/main.go
+++ b/main.go
@@ -140,12 +140,7 @@ func main() {
 			cmd.Execute()
 		}()
 
-		_, err := progress.Progress.Run()
-
-		if err != nil {
-			log.Error().Msgf("error running bubble tea: %v", err)
-			os.Exit(1)
-		}
+		progress.Progress.Run()
 
 	} else {
 		cmd.Execute()

--- a/main.go
+++ b/main.go
@@ -140,7 +140,13 @@ func main() {
 			cmd.Execute()
 		}()
 
-		progress.Progress.Run()
+		_, err := progress.Progress.Run()
+
+		if err != nil {
+			log.Error().Msgf("error running bubble tea: %v", err)
+			os.Exit(1)
+		}
+
 	} else {
 		cmd.Execute()
 	}


### PR DESCRIPTION
Signed-off-by: nathan-nicholson <nathan@konstruct.io>

## Description

Since the differences between clouds are minimal, extra structs are overhead.

Create Provisioner struct that's used across commands.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
