### PR TITLE
fix: display error messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/konstructio/kubefirst/cmd/k3s"
 	"github.com/konstructio/kubefirst/cmd/vultr"
 	"github.com/konstructio/kubefirst/internal/common"
+	"github.com/konstructio/kubefirst/internal/step"
 	"github.com/spf13/cobra"
 )
 
@@ -73,6 +74,7 @@ func Execute() {
 	// Before removing next line, please read ticket above.
 	common.CheckForVersionUpdate()
 	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(output, step.EmojiError, "Error:", err)
 		fmt.Fprintln(output, "If a detailed error message was available, please make the necessary corrections before retrying.")
 		fmt.Fprintln(output, "You can re-run the last command to try the operation again.")
 		os.Exit(0)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,7 @@ func Execute() {
 	// Before removing next line, please read ticket above.
 	common.CheckForVersionUpdate()
 	if err := rootCmd.Execute(); err != nil {
+		fmt.Println()
 		fmt.Fprintln(output, step.EmojiError, "Error:", err)
 		fmt.Fprintln(output, "If a detailed error message was available, please make the necessary corrections before retrying.")
 		fmt.Fprintln(output, "You can re-run the last command to try the operation again.")

--- a/internal/launch/cmd.go
+++ b/internal/launch/cmd.go
@@ -187,9 +187,9 @@ func Up(ctx context.Context, additionalHelmFlags []string, inCluster, useTelemet
 		_, _, err := shell.ExecShellReturnStrings(
 			k3dClient,
 			"kubeconfig",
-			"get",
+			"write",
 			consoleClusterName,
-			"--output",
+			"-o",
 			kubeconfigPath,
 		)
 		if err != nil {


### PR DESCRIPTION
## Description
Display the error message for cli

## How to test

Example cmd to show the error :
```go run . k3s create --git-provider gitlab  --gitlab-group ar373 --alerts-email 1@gmail.com --dns-provider cloudflare --domain-name kubefirst.xyz```
